### PR TITLE
chore: document feature worktree and PR workflow in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -53,6 +53,40 @@ Use small, atomic commits with [Conventional Commits](https://www.conventionalco
 
 **Use the `frontend-design` skill** when building or significantly redesigning UI components, pages, or layouts in the demo application. Invoke it via the Skill tool before writing Svelte/CSS code for any non-trivial UI work.
 
+## Feature Worktrees
+
+**Every new feature must be developed in a dedicated git worktree** — never directly on `master`. When starting a feature, create a worktree on a new branch:
+
+```bash
+git worktree add .claude/worktrees/<branch-name> -b <branch-name>
+```
+
+Work entirely within that worktree, then remove it after the PR is merged:
+
+```bash
+git worktree remove .claude/worktrees/<branch-name>
+git branch -d <branch-name>
+```
+
+## Pull Request Workflow
+
+**Use the `/create-pr` skill** to automate the full PR creation flow. It will:
+
+1. Ensure all commits on the feature branch are GPG-signed — re-signs any unsigned commits with:
+   ```bash
+   git rebase --exec "git commit --amend --no-edit -S" origin/master
+   ```
+2. Fetch and rebase the branch on the latest `origin/master` (with signing).
+3. Force-push with `--force-with-lease`.
+4. Create the PR on GitHub using `gh pr create`.
+5. Open the PR URL in the browser with `open <pr-url>`.
+
+**GPG signing is required.** Branch protection on `master` enforces verified signatures. The signing key is already configured (`commit.gpgsign = true`, key `CD42639745A71184`). To re-sign all commits on a branch manually:
+
+```bash
+git rebase --exec "git commit --amend --no-edit -S" origin/master
+```
+
 ## Area-Specific Rules
 
 @rules/demo.md

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: create-pr
+description: Automates the full pull request creation flow — re-signs commits, rebases on origin/master, force-pushes, creates the PR with gh, and opens it in the browser.
+---
+
+Perform the full PR creation flow for the current feature branch. Execute each step in order, stopping and reporting any error rather than continuing past a failure.
+
+## Steps
+
+### 1. Identify the current branch
+
+```bash
+git branch --show-current
+```
+
+Abort if the branch is `master` — PRs must come from feature branches.
+
+### 2. Re-sign any unsigned commits
+
+Check whether every commit on the branch (reachable from HEAD but not from `origin/master`) carries a GPG signature:
+
+```bash
+git log origin/master..HEAD --format="%H %G?"
+```
+
+If any line shows `G?` as `N` (no signature), re-sign the full range:
+
+```bash
+git rebase --exec "git commit --amend --no-edit -S" origin/master
+```
+
+### 3. Fetch and rebase on the latest origin/master
+
+```bash
+git fetch origin
+git rebase --exec "git commit --amend --no-edit -S" origin/master
+```
+
+This rebases and ensures all commits — including any already-signed ones — remain signed after the rebase.
+
+### 4. Force-push the branch
+
+```bash
+git push origin HEAD --force-with-lease
+```
+
+### 5. Derive PR title and body from commits
+
+Inspect the commits that will be in the PR:
+
+```bash
+git log origin/master..HEAD --oneline
+```
+
+Compose a concise PR title (under 70 characters) and a markdown body summarising the changes. Use the commit messages as the primary source. The body should follow this structure:
+
+```
+## Summary
+- <bullet points describing what changed and why>
+
+## Test plan
+- [ ] <key things a reviewer should verify>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### 6. Create the PR
+
+```bash
+gh pr create --title "<title>" --body "<body>"
+```
+
+Capture the PR URL printed by `gh pr create`.
+
+### 7. Open the PR in the browser
+
+```bash
+open <pr-url>
+```
+
+Report the PR URL to the user.


### PR DESCRIPTION
## Summary

- Adds **Feature Worktrees** rule: every new feature must be developed in a dedicated git worktree (never directly on \`master\`)
- Adds **Pull Request Workflow** section documenting the \`/create-pr\` skill — GPG re-sign, rebase on latest master, force-push, \`gh pr create\`, \`open\` in browser
- Creates \`.claude/skills/create-pr/SKILL.md\` with step-by-step instructions Claude follows when the skill is invoked

## Test plan

- [ ] Start a new feature and verify Claude creates a worktree automatically
- [ ] Run \`/create-pr\` and verify it re-signs, rebases, pushes, creates the PR, and opens it in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)