### PR TITLE
refactor: migrate private fields to native # syntax

### DIFF
--- a/.claude/rules/blockEditor.md
+++ b/.claude/rules/blockEditor.md
@@ -38,6 +38,16 @@ Do not inject styles via JavaScript or use inline `style` attributes for anythin
 - Do not test DOM rendering directly; test the data transformations that drive it
 - Run a single file: `pnpm vitest run src/lib/block-editor/text/text.test.ts`
 
+## Private Fields
+
+Use **JavaScript native `#` private fields** for all private class members. Do not use TypeScript's `private` keyword or the `_` prefix convention.
+
+- `#` fields are enforced at **runtime** — they cannot be bypassed via bracket notation, `Object.keys`, JSON serialization, or Proxy.
+- TypeScript's `private` keyword is compile-time only; the field is a plain public property at runtime.
+- The `_` prefix is a legacy convention with no enforcement — actively discouraged by the Google TypeScript Style Guide and the TypeScript team.
+- For members that subclasses must access, use TypeScript's `protected` keyword (no `#` equivalent exists).
+- When accessing a private **static** `#` field, always reference it via the class name — never via `this` — to avoid a `TypeError` when the method is inherited.
+
 ## Component Patterns
 
 All UI components follow a **class-based pattern** — no Web Components, no framework.
@@ -48,30 +58,30 @@ All UI components follow a **class-based pattern** — no Web Components, no fra
 
 ```typescript
 class MyComponent {
-  private _root: HTMLElement
-  private _onFoo = () => { /* arrow fn stored as field for removeEventListener */ }
+  #root: HTMLElement
+  #onFoo = () => { /* arrow fn stored as field for removeEventListener */ }
 
   constructor(container: HTMLElement, opts: MyOptions) {
-    // Build DOM, attach listeners, call _render()
-    document.addEventListener('selectionchange', this._onFoo)
+    // Build DOM, attach listeners, call #render()
+    document.addEventListener('selectionchange', this.#onFoo)
   }
 
   getValue(): State { ... }
-  setValue(state: State): void { this._state = state; this._render() }
+  setValue(state: State): void { this.#state = state; this.#render() }
   onChange(cb: (state: State) => void): () => void { /* return unsubscribe fn */ }
 
   destroy(): void {
-    this._root.remove()
-    document.removeEventListener('selectionchange', this._onFoo) // must remove global listeners
+    this.#root.remove()
+    document.removeEventListener('selectionchange', this.#onFoo) // must remove global listeners
   }
 
-  private _render(): void { /* idempotent DOM sync — never recreate; only patch */ }
+  #render(): void { /* idempotent DOM sync — never recreate; only patch */ }
 }
 ```
 
 **Lifecycle rules:**
-- `constructor` — create DOM, register listeners, call `_render()`
-- `_render()` — private, idempotent, projects state → DOM; never recreate chrome, only patch (toggle classes/attributes)
+- `constructor` — create DOM, register listeners, call `#render()`
+- `#render()` — private, idempotent, projects state → DOM; never recreate chrome, only patch (toggle classes/attributes)
 - `destroy()` — remove created DOM, **always detach global listeners** (`document`, `window`) stored as private arrow-function fields
 - Upward communication via subscription (`onChange(cb): () => void`) — fully type-safe, no `CustomEvent` dispatch
 
@@ -107,9 +117,9 @@ Bidirectional conversion between `Text` and arrays of DOM nodes.
 
 `TextEditor` is a self-contained UI component. It imports its CSS, builds a toolbar + `contenteditable` div, and wires everything together.
 
-- `_render()` serializes the current `Text` state to DOM and restores selection.
-- `_handleInput()` parses the edited DOM back to `Text` and calls change listeners.
-- `_applyOrRemoveInline()` toggles formatting on the current selection using `isToggled`.
+- `#render()` serializes the current `Text` state to DOM and restores selection.
+- `#handleInput()` parses the edited DOM back to `Text` and calls change listeners.
+- `#applyOrRemoveInline()` toggles formatting on the current selection using `isToggled`.
 - Selection is mapped between DOM positions and character offsets via `getCharOffset` / `findNodeAtOffset`.
 - IME composition events are handled separately to avoid premature parses.
 
@@ -144,6 +154,6 @@ Newly added blocks (not in old state) are ignored. Use this to compute `blockRem
 - Immediate `emit`
 - Debounced `scheduleDataUpdated` (with `flushDataUpdated`, `cancelDataUpdated`, `flushAll`, `cancelAll`)
 
-`BlockEditor` holds a single `private _emitter: BlockEventEmitter` — it never manages listener maps or timers directly.
+`BlockEditor` holds a single `#emitter: BlockEventEmitter` — it never manages listener maps or timers directly.
 
 `BLOCK_EDITOR_EVENT_NAMES` (exported from `events.ts` and `index.ts`) is a compile-time-exhaustive tuple of all event names. Use it in tests and any code that must handle every event type.

--- a/src/lib/block-editor/editor/BlockEditor.ts
+++ b/src/lib/block-editor/editor/BlockEditor.ts
@@ -90,33 +90,33 @@ function insertChar(text: Text, offset: number, char: string): Text {
 // ─── BlockEditor ─────────────────────────────────────────────────────────────
 
 export class BlockEditor {
-  private _state: Blocks
-  private _editable: HTMLDivElement
-  private _emitter: BlockEventEmitter
+  #state: Blocks
+  #editable: HTMLDivElement
+  #emitter: BlockEventEmitter
   /**
    * IME composition guard.
    * Set true on compositionstart, false on compositionend.
-   * _handleInput is a no-op while composing, then fires once on compositionend.
+   * #handleInput is a no-op while composing, then fires once on compositionend.
    */
-  private _composing = false
+  #composing = false
 
-  private _onSelectionChange = (): void => {
-    if (document.activeElement === this._editable) {
-      this._emitter.emit('selectionChange', this._getSelection())
+  #onSelectionChange = (): void => {
+    if (document.activeElement === this.#editable) {
+      this.#emitter.emit('selectionChange', this.#getSelection())
     }
   }
 
-  private _onBlur = (): void => {
-    this._emitter.flushAll()
-    this._emitter.emit('selectionChange', null)
+  #onBlur = (): void => {
+    this.#emitter.flushAll()
+    this.#emitter.emit('selectionChange', null)
   }
 
   constructor(container: HTMLElement, initial?: Blocks, opts: BlockEditorOptions = {}) {
-    this._state = initial ?? Blocks.from([Blocks.createBlock()])
-    this._emitter = new BlockEventEmitter(
+    this.#state = initial ?? Blocks.from([Blocks.createBlock()])
+    this.#emitter = new BlockEventEmitter(
       (id) => {
         try {
-          const block = this._state.getBlock(id)
+          const block = this.#state.getBlock(id)
           return { id, data: block.data }
         } catch {
           return null  // block was removed; skip
@@ -128,43 +128,43 @@ export class BlockEditor {
       },
     )
 
-    this._editable = document.createElement('div')
-    this._editable.className = 'block-editor-editable'
-    this._editable.contentEditable = 'true'
+    this.#editable = document.createElement('div')
+    this.#editable.className = 'block-editor-editable'
+    this.#editable.contentEditable = 'true'
 
-    this._editable.addEventListener('keydown', (e) => this._handleKeyDown(e))
-    this._editable.addEventListener('input', () => this._handleInput())
-    this._editable.addEventListener('blur', this._onBlur)
-    this._editable.addEventListener('compositionstart', () => {
+    this.#editable.addEventListener('keydown', (e) => this.#handleKeyDown(e))
+    this.#editable.addEventListener('input', () => this.#handleInput())
+    this.#editable.addEventListener('blur', this.#onBlur)
+    this.#editable.addEventListener('compositionstart', () => {
       // If there is a multi-block selection, delete it before composition starts
-      const sel = this._getSelection()
+      const sel = this.#getSelection()
       if (sel instanceof BlockRange) {
-        const cursor = this._deleteRange(sel)
-        this._render(cursor)
+        const cursor = this.#deleteRange(sel)
+        this.#render(cursor)
       }
-      this._composing = true
+      this.#composing = true
     })
-    this._editable.addEventListener('compositionend', () => {
-      this._composing = false
-      this._handleInput()
+    this.#editable.addEventListener('compositionend', () => {
+      this.#composing = false
+      this.#handleInput()
     })
 
-    document.addEventListener('selectionchange', this._onSelectionChange)
+    document.addEventListener('selectionchange', this.#onSelectionChange)
 
-    container.appendChild(this._editable)
-    this._render()
+    container.appendChild(this.#editable)
+    this.#render()
   }
 
   // ─── Public API ────────────────────────────────────────────────────────────
 
   getValue(): Blocks {
-    return this._state
+    return this.#state
   }
 
   setValue(blocks: Blocks): void {
-    this._emitter.cancelAll()
-    this._state = blocks
-    this._render()
+    this.#emitter.cancelAll()
+    this.#state = blocks
+    this.#render()
     // no events
   }
 
@@ -173,36 +173,36 @@ export class BlockEditor {
     event: K,
     handler: (payload: BlockEditorEventMap[K]) => void,
   ): () => void {
-    return this._emitter.addEventListener(event, handler)
+    return this.#emitter.addEventListener(event, handler)
   }
 
   /** Indent current block range; re-render preserving full BlockSelection. */
   indent(): void {
-    const sel = this._getSelection()
+    const sel = this.#getSelection()
     if (!sel) return
     const fromId = sel instanceof BlockRange ? sel.start.blockId : sel.blockId
     const toId = sel instanceof BlockRange ? sel.end.blockId : sel.blockId
-    const oldState = this._state
-    this._state = this._state.indent(fromId, toId)
-    this._render(sel)
-    this._emitEvents(oldState)
+    const oldState = this.#state
+    this.#state = this.#state.indent(fromId, toId)
+    this.#render(sel)
+    this.#emitEvents(oldState)
   }
 
   /** Unindent current block range; re-render preserving full BlockSelection. */
   outdent(): void {
-    const sel = this._getSelection()
+    const sel = this.#getSelection()
     if (!sel) return
     const fromId = sel instanceof BlockRange ? sel.start.blockId : sel.blockId
     const toId = sel instanceof BlockRange ? sel.end.blockId : sel.blockId
-    const oldState = this._state
-    this._state = this._state.unindent(fromId, toId)
-    this._render(sel)
-    this._emitEvents(oldState)
+    const oldState = this.#state
+    this.#state = this.#state.unindent(fromId, toId)
+    this.#render(sel)
+    this.#emitEvents(oldState)
   }
 
   /** Toggle inline format on selection within focused block. */
   toggleInline(type: InlineTypes): void {
-    const sel = this._getSelection()
+    const sel = this.#getSelection()
     if (!sel) return
 
     let blockId: BlockId
@@ -218,7 +218,7 @@ export class BlockEditor {
       return
     }
 
-    const block = this._state.getBlock(blockId)
+    const block = this.#state.getBlock(blockId)
     const text = new Text(block.data.text, [...block.data.inline] as InlineDto[])
     if (start >= end || end > text.text.length) return
 
@@ -227,19 +227,19 @@ export class BlockEditor {
       ? text.removeInline(type, start, end)
       : text.addInline(type, start, end)
 
-    const oldState = this._state
-    this._state = this._state.update(blockId, newText)
-    this._render(sel)
-    this._emitEvents(oldState)
+    const oldState = this.#state
+    this.#state = this.#state.update(blockId, newText)
+    this.#render(sel)
+    this.#emitEvents(oldState)
   }
 
   /** Returns true if the inline is fully active on the current selection. */
   isInlineActive(type: InlineTypes): boolean {
-    const sel = this._getSelection()
+    const sel = this.#getSelection()
     if (!(sel instanceof BlockRange)) return false
     if (sel.start.blockId !== sel.end.blockId) return false
 
-    const block = this._state.getBlock(sel.start.blockId)
+    const block = this.#state.getBlock(sel.start.blockId)
     const start = sel.start.offset
     const end = sel.end.offset
     if (start >= end || end > block.data.text.length) return false
@@ -253,83 +253,83 @@ export class BlockEditor {
   }
 
   destroy(): void {
-    this._emitter.flushAll()
-    this._emitter.cancelAll()
-    document.removeEventListener('selectionchange', this._onSelectionChange)
-    this._editable.remove()
+    this.#emitter.flushAll()
+    this.#emitter.cancelAll()
+    document.removeEventListener('selectionchange', this.#onSelectionChange)
+    this.#editable.remove()
   }
 
   // ─── Private helpers ────────────────────────────────────────────────────────
 
-  private _emitEvents(oldState: Blocks): void {
-    const changes = Blocks.diff(oldState, this._state)
-    this._emitter.cancelAll()
+  #emitEvents(oldState: Blocks): void {
+    const changes = Blocks.diff(oldState, this.#state)
+    this.#emitter.cancelAll()
 
     // Emit in a stable semantic order: dataChanged → added → removed → moved
     for (const change of changes) {
       if (change.type === 'dataChanged') {
-        this._emitter.emit('blockDataUpdated', { id: change.id, data: change.data })
+        this.#emitter.emit('blockDataUpdated', { id: change.id, data: change.data })
       }
     }
     for (const change of changes) {
       if (change.type === 'added') {
-        this._emitter.emit('blockCreated', { id: change.id, data: change.data, previousBlockId: change.previousBlockId, parentBlockId: change.parentBlockId })
+        this.#emitter.emit('blockCreated', { id: change.id, data: change.data, previousBlockId: change.previousBlockId, parentBlockId: change.parentBlockId })
       }
     }
     for (const change of changes) {
       if (change.type === 'removed') {
-        this._emitter.emit('blockRemoved', { id: change.id })
+        this.#emitter.emit('blockRemoved', { id: change.id })
       }
     }
     for (const change of changes) {
       if (change.type === 'moved') {
-        this._emitter.emit('blockMoved', { id: change.id, previousBlockId: change.previousBlockId, parentBlockId: change.parentBlockId })
+        this.#emitter.emit('blockMoved', { id: change.id, previousBlockId: change.previousBlockId, parentBlockId: change.parentBlockId })
       }
     }
   }
 
   // ─── Private ───────────────────────────────────────────────────────────────
 
-  private _render(selection?: BlockSelection): void {
-    const focused = document.activeElement === this._editable
+  #render(selection?: BlockSelection): void {
+    const focused = document.activeElement === this.#editable
 
     let savedSel: BlockSelection | undefined = selection
     if (savedSel === undefined && focused) {
-      savedSel = this._getSelection() ?? undefined
+      savedSel = this.#getSelection() ?? undefined
     }
 
-    this._editable.innerHTML = ''
-    const nodes = blocksSerializer.render(this._state)
+    this.#editable.innerHTML = ''
+    const nodes = blocksSerializer.render(this.#state)
     for (const node of nodes) {
-      this._editable.appendChild(node)
+      this.#editable.appendChild(node)
     }
 
     // Restore when selection was explicitly passed, or when we saved it because we were focused
     if (savedSel !== undefined) {
       try {
-        this._restoreSelection(savedSel)
+        this.#restoreSelection(savedSel)
       } catch {
         // best-effort
       }
     }
   }
 
-  private _restoreSelection(sel: BlockSelection): void {
+  #restoreSelection(sel: BlockSelection): void {
     const domSel = window.getSelection()
     if (!domSel) return
 
     const range = document.createRange()
 
     if (sel instanceof BlockOffset) {
-      const blockEl = this._editable.querySelector(`[id="${sel.blockId}"]`)
+      const blockEl = this.#editable.querySelector(`[id="${sel.blockId}"]`)
       if (!blockEl) return
       const p = getBlockElementContent(blockEl)
       const { node, offset } = findNodeAtOffset(p, sel.offset)
       range.setStart(node, offset)
       range.setEnd(node, offset)
     } else {
-      const startBlockEl = this._editable.querySelector(`[id="${sel.start.blockId}"]`)
-      const endBlockEl = this._editable.querySelector(`[id="${sel.end.blockId}"]`)
+      const startBlockEl = this.#editable.querySelector(`[id="${sel.start.blockId}"]`)
+      const endBlockEl = this.#editable.querySelector(`[id="${sel.end.blockId}"]`)
       if (!startBlockEl || !endBlockEl) return
       const startP = getBlockElementContent(startBlockEl)
       const endP = getBlockElementContent(endBlockEl)
@@ -343,13 +343,13 @@ export class BlockEditor {
     domSel.addRange(range)
   }
 
-  private _getSelection(): BlockSelection | null {
+  #getSelection(): BlockSelection | null {
     const domSel = window.getSelection()
     if (!domSel || domSel.rangeCount === 0) return null
 
     const range = domSel.getRangeAt(0)
-    if (!this._editable.contains(range.startContainer)) return null
-    if (!this._editable.contains(range.endContainer)) return null
+    if (!this.#editable.contains(range.startContainer)) return null
+    if (!this.#editable.contains(range.endContainer)) return null
 
     const startBlockEl = getBlockElement(range.startContainer)
     const endBlockEl = getBlockElement(range.endContainer)
@@ -381,14 +381,14 @@ export class BlockEditor {
     )
   }
 
-  private _handleKeyDown(e: KeyboardEvent): void {
-    if (this._composing) return
+  #handleKeyDown(e: KeyboardEvent): void {
+    if (this.#composing) return
 
-    const sel = this._getSelection()
+    const sel = this.#getSelection()
 
     if (e.key === 'Enter') {
       e.preventDefault()
-      if (sel) this._handleEnter(sel)
+      if (sel) this.#handleEnter(sel)
       return
     }
 
@@ -420,12 +420,12 @@ export class BlockEditor {
     if (e.key === 'Backspace') {
       if (sel instanceof BlockRange) {
         e.preventDefault()
-        this._handleBackspace(sel)
+        this.#handleBackspace(sel)
         return
       }
       if (sel instanceof BlockOffset && sel.offset === 0) {
         e.preventDefault()
-        this._handleBackspace(sel)
+        this.#handleBackspace(sel)
         return
       }
       return
@@ -434,14 +434,14 @@ export class BlockEditor {
     if (e.key === 'Delete') {
       if (sel instanceof BlockRange) {
         e.preventDefault()
-        this._handleDelete(sel)
+        this.#handleDelete(sel)
         return
       }
       if (sel instanceof BlockOffset) {
-        const block = this._state.getBlock(sel.blockId)
+        const block = this.#state.getBlock(sel.blockId)
         if (sel.offset === block.getLength()) {
           e.preventDefault()
-          this._handleDelete(sel)
+          this.#handleDelete(sel)
           return
         }
       }
@@ -457,109 +457,109 @@ export class BlockEditor {
       !e.altKey
     ) {
       e.preventDefault()
-      const cursor = this._deleteRange(sel)
-      const block = this._state.getBlock(cursor.blockId)
+      const cursor = this.#deleteRange(sel)
+      const block = this.#state.getBlock(cursor.blockId)
       const text = new Text(block.data.text, [...block.data.inline] as InlineDto[])
       const newText = insertChar(text, cursor.offset, e.key)
       const newCursor = new BlockOffset(cursor.blockId, cursor.offset + 1)
-      this._state = this._state.update(cursor.blockId, newText)
-      this._render(newCursor)
-      this._emitter.scheduleDataUpdated(cursor.blockId)
+      this.#state = this.#state.update(cursor.blockId, newText)
+      this.#render(newCursor)
+      this.#emitter.scheduleDataUpdated(cursor.blockId)
       return
     }
   }
 
-  private _handleInput(): void {
-    if (this._composing) return
+  #handleInput(): void {
+    if (this.#composing) return
 
-    const sel = this._getSelection()
+    const sel = this.#getSelection()
     if (sel instanceof BlockRange) {
       throw new Error('BlockEditor invariant violated: multi-block selection during input')
     }
     if (!sel) return
 
     const { blockId } = sel
-    const blockEl = this._editable.querySelector(`[id="${blockId}"]`)
+    const blockEl = this.#editable.querySelector(`[id="${blockId}"]`)
     if (!blockEl) return
 
     const pEl = getBlockElementContent(blockEl)
     const newText = textSerializer.parse(Array.from(pEl.childNodes))
-    this._state = this._state.update(blockId, newText)
-    this._render(sel)
-    this._emitter.scheduleDataUpdated(blockId)
+    this.#state = this.#state.update(blockId, newText)
+    this.#render(sel)
+    this.#emitter.scheduleDataUpdated(blockId)
   }
 
-  private _handleEnter(sel: BlockSelection): void {
+  #handleEnter(sel: BlockSelection): void {
     if (sel instanceof BlockRange) {
-      const cursor = this._deleteRange(sel)
-      this._render(cursor)
+      const cursor = this.#deleteRange(sel)
+      this.#render(cursor)
       return
     }
     // BlockOffset: split
     const { blockId, offset } = sel
-    const block = this._state.getBlock(blockId)
+    const block = this.#state.getBlock(blockId)
     const atEnd = offset === block.getLength()
 
     if (atEnd) {
-      this._emitter.flushDataUpdated(blockId)
+      this.#emitter.flushDataUpdated(blockId)
     }
 
-    const oldState = this._state
+    const oldState = this.#state
     const newId = crypto.randomUUID()
-    this._state = this._state.splitAt(blockId, offset, newId)
-    this._render(new BlockOffset(newId, 0))
-    this._emitEvents(oldState)
+    this.#state = this.#state.splitAt(blockId, offset, newId)
+    this.#render(new BlockOffset(newId, 0))
+    this.#emitEvents(oldState)
   }
 
-  private _handleBackspace(sel: BlockSelection): void {
+  #handleBackspace(sel: BlockSelection): void {
     if (sel instanceof BlockRange) {
-      const cursor = this._deleteRange(sel)
-      this._render(cursor)
+      const cursor = this.#deleteRange(sel)
+      this.#render(cursor)
       return
     }
     // BlockOffset at offset 0
     const { blockId } = sel
-    const prevId = this._state.previousBlockId(blockId)
+    const prevId = this.#state.previousBlockId(blockId)
     if (prevId === null) return  // first block — no-op
-    const cursorOffset = this._state.getBlock(prevId).getLength()
-    const oldState = this._state
-    this._state = this._state.merge(prevId, blockId)
-    this._render(new BlockOffset(prevId, cursorOffset))
-    this._emitEvents(oldState)
+    const cursorOffset = this.#state.getBlock(prevId).getLength()
+    const oldState = this.#state
+    this.#state = this.#state.merge(prevId, blockId)
+    this.#render(new BlockOffset(prevId, cursorOffset))
+    this.#emitEvents(oldState)
   }
 
-  private _handleDelete(sel: BlockSelection): void {
+  #handleDelete(sel: BlockSelection): void {
     if (sel instanceof BlockRange) {
-      const cursor = this._deleteRange(sel)
-      this._render(cursor)
+      const cursor = this.#deleteRange(sel)
+      this.#render(cursor)
       return
     }
     // BlockOffset at end of block
     const { blockId } = sel
-    const nextId = this._state.nextBlockId(blockId)
+    const nextId = this.#state.nextBlockId(blockId)
     if (nextId === null) return  // last block — no-op
-    const cursorOffset = this._state.getBlock(blockId).getLength()
-    const oldState = this._state
-    this._state = this._state.merge(blockId, nextId)
-    this._render(new BlockOffset(blockId, cursorOffset))
-    this._emitEvents(oldState)
+    const cursorOffset = this.#state.getBlock(blockId).getLength()
+    const oldState = this.#state
+    this.#state = this.#state.merge(blockId, nextId)
+    this.#render(new BlockOffset(blockId, cursorOffset))
+    this.#emitEvents(oldState)
   }
 
-  private _deleteRange(sel: BlockRange): BlockOffset {
+  #deleteRange(sel: BlockRange): BlockOffset {
     if (sel.start.blockId === sel.end.blockId) {
-      const block = this._state.getBlock(sel.start.blockId)
+      const block = this.#state.getBlock(sel.start.blockId)
       const text = new Text(block.data.text, [...block.data.inline] as InlineDto[])
       const length = sel.end.offset - sel.start.offset
       const newText = text.remove(sel.start.offset, length)
-      const oldState = this._state
-      this._state = this._state.update(sel.start.blockId, newText)
-      this._emitEvents(oldState)
+      const oldState = this.#state
+      this.#state = this.#state.update(sel.start.blockId, newText)
+      this.#emitEvents(oldState)
       return new BlockOffset(sel.start.blockId, sel.start.offset)
     }
     // Multi-block
-    const oldState = this._state
-    this._state = this._state.deleteRange(sel)
-    this._emitEvents(oldState)
+    const oldState = this.#state
+    this.#state = this.#state.deleteRange(sel)
+    this.#emitEvents(oldState)
     return new BlockOffset(sel.start.blockId, sel.start.offset)
   }
 }

--- a/src/lib/block-editor/editor/BlockEditorWithToolbar.ts
+++ b/src/lib/block-editor/editor/BlockEditorWithToolbar.ts
@@ -18,21 +18,21 @@ function addTooltip(btn: HTMLButtonElement, label: string, shortcut?: string): v
 }
 
 export class BlockEditorWithToolbar {
-  private _editor: BlockEditor
-  private _toolbar: HTMLDivElement
+  #editor: BlockEditor
+  #toolbar: HTMLDivElement
   /**
    * Record<InlineTypes, ...> ensures TypeScript errors if any inline type
    * is missing a button. Exhaustiveness is verified at compile time.
    */
-  private _inlineButtons: Record<InlineTypes, HTMLButtonElement>
-  private _indentBtn: HTMLButtonElement
-  private _outdentBtn: HTMLButtonElement
-  private _unsubscribeSelection: () => void
+  #inlineButtons: Record<InlineTypes, HTMLButtonElement>
+  #indentBtn: HTMLButtonElement
+  #outdentBtn: HTMLButtonElement
+  #unsubscribeSelection: () => void
 
   constructor(container: HTMLElement, initial?: Blocks, opts: BlockEditorOptions = {}) {
     // Build toolbar
-    this._toolbar = document.createElement('div')
-    this._toolbar.className = 'text-editor-toolbar'
+    this.#toolbar = document.createElement('div')
+    this.#toolbar.className = 'text-editor-toolbar'
 
     const inlineDefs: { type: InlineTypes; icon: Parameters<typeof createElement>[0]; shortcut: string }[] = [
       { type: 'Bold', icon: Bold, shortcut: '⌘B' },
@@ -40,7 +40,7 @@ export class BlockEditorWithToolbar {
       { type: 'Underline', icon: Underline, shortcut: '⌘U' },
     ] satisfies { type: keyof InlineDtoMap; icon: Parameters<typeof createElement>[0]; shortcut: string }[]
 
-    this._inlineButtons = {} as Record<InlineTypes, HTMLButtonElement>
+    this.#inlineButtons = {} as Record<InlineTypes, HTMLButtonElement>
     for (const { type, icon, shortcut } of inlineDefs) {
       const btn = document.createElement('button')
       btn.appendChild(createElement(icon))
@@ -49,64 +49,64 @@ export class BlockEditorWithToolbar {
       addTooltip(btn, type, shortcut)
       btn.addEventListener('mousedown', (e) => {
         e.preventDefault()
-        this._editor.toggleInline(type)
+        this.#editor.toggleInline(type)
       })
-      this._toolbar.appendChild(btn)
-      this._inlineButtons[type] = btn
+      this.#toolbar.appendChild(btn)
+      this.#inlineButtons[type] = btn
     }
 
-    this._indentBtn = document.createElement('button')
-    this._indentBtn.appendChild(createElement(IndentIncrease))
-    this._indentBtn.ariaLabel = 'Indent'
-    this._indentBtn.title = 'Indent'
-    addTooltip(this._indentBtn, 'Indent', 'Tab')
-    this._indentBtn.addEventListener('mousedown', (e) => {
+    this.#indentBtn = document.createElement('button')
+    this.#indentBtn.appendChild(createElement(IndentIncrease))
+    this.#indentBtn.ariaLabel = 'Indent'
+    this.#indentBtn.title = 'Indent'
+    addTooltip(this.#indentBtn, 'Indent', 'Tab')
+    this.#indentBtn.addEventListener('mousedown', (e) => {
       e.preventDefault()
-      this._editor.indent()
+      this.#editor.indent()
     })
-    this._toolbar.appendChild(this._indentBtn)
+    this.#toolbar.appendChild(this.#indentBtn)
 
-    this._outdentBtn = document.createElement('button')
-    this._outdentBtn.appendChild(createElement(IndentDecrease))
-    this._outdentBtn.ariaLabel = 'Outdent'
-    this._outdentBtn.title = 'Outdent'
-    addTooltip(this._outdentBtn, 'Outdent', '⇧Tab')
-    this._outdentBtn.addEventListener('mousedown', (e) => {
+    this.#outdentBtn = document.createElement('button')
+    this.#outdentBtn.appendChild(createElement(IndentDecrease))
+    this.#outdentBtn.ariaLabel = 'Outdent'
+    this.#outdentBtn.title = 'Outdent'
+    addTooltip(this.#outdentBtn, 'Outdent', '⇧Tab')
+    this.#outdentBtn.addEventListener('mousedown', (e) => {
       e.preventDefault()
-      this._editor.outdent()
+      this.#editor.outdent()
     })
-    this._toolbar.appendChild(this._outdentBtn)
+    this.#toolbar.appendChild(this.#outdentBtn)
 
-    container.appendChild(this._toolbar)
+    container.appendChild(this.#toolbar)
 
-    this._editor = new BlockEditor(container, initial, opts)
+    this.#editor = new BlockEditor(container, initial, opts)
 
     // Update toolbar active state on selection change
-    this._unsubscribeSelection = this._editor.addEventListener('selectionChange', () => {
-      for (const type of Object.keys(this._inlineButtons) as InlineTypes[]) {
-        this._inlineButtons[type].classList.toggle('is-active', this._editor.isInlineActive(type))
+    this.#unsubscribeSelection = this.#editor.addEventListener('selectionChange', () => {
+      for (const type of Object.keys(this.#inlineButtons) as InlineTypes[]) {
+        this.#inlineButtons[type].classList.toggle('is-active', this.#editor.isInlineActive(type))
       }
     })
   }
 
   getValue(): Blocks {
-    return this._editor.getValue()
+    return this.#editor.getValue()
   }
 
   setValue(blocks: Blocks): void {
-    this._editor.setValue(blocks)
+    this.#editor.setValue(blocks)
   }
 
   addEventListener<K extends keyof BlockEditorEventMap>(
     event: K,
     handler: (payload: BlockEditorEventMap[K]) => void,
   ): () => void {
-    return this._editor.addEventListener(event, handler)
+    return this.#editor.addEventListener(event, handler)
   }
 
   destroy(): void {
-    this._unsubscribeSelection()
-    this._toolbar.remove()
-    this._editor.destroy()
+    this.#unsubscribeSelection()
+    this.#toolbar.remove()
+    this.#editor.destroy()
   }
 }

--- a/src/lib/block-editor/editor/BlockEventEmitter.ts
+++ b/src/lib/block-editor/editor/BlockEventEmitter.ts
@@ -3,76 +3,76 @@ import type { BlockEditorEventMap, BlockDataUpdatedEvent } from './events'
 import { makeDebounced, type DebouncedFn } from './debounce'
 
 export class BlockEventEmitter {
-  private _listeners: Map<keyof BlockEditorEventMap, Set<(payload: unknown) => void>> = new Map()
-  private _pending: Map<BlockId, DebouncedFn> = new Map()
-  private _getBlockData: (id: BlockId) => BlockDataUpdatedEvent | null
-  private _debounceMs: number
-  private _maxWaitMs: number
+  #listeners: Map<keyof BlockEditorEventMap, Set<(payload: unknown) => void>> = new Map()
+  #pending: Map<BlockId, DebouncedFn> = new Map()
+  #getBlockData: (id: BlockId) => BlockDataUpdatedEvent | null
+  #debounceMs: number
+  #maxWaitMs: number
 
   constructor(
     getBlockData: (id: BlockId) => BlockDataUpdatedEvent | null,
     opts: { debounceMs: number; maxWaitMs: number },
   ) {
-    this._getBlockData = getBlockData
-    this._debounceMs = opts.debounceMs
-    this._maxWaitMs = opts.maxWaitMs
+    this.#getBlockData = getBlockData
+    this.#debounceMs = opts.debounceMs
+    this.#maxWaitMs = opts.maxWaitMs
   }
 
   addEventListener<K extends keyof BlockEditorEventMap>(
     event: K,
     handler: (payload: BlockEditorEventMap[K]) => void,
   ): () => void {
-    if (!this._listeners.has(event)) {
-      this._listeners.set(event, new Set())
+    if (!this.#listeners.has(event)) {
+      this.#listeners.set(event, new Set())
     }
-    this._listeners.get(event)!.add(handler as (payload: unknown) => void)
-    return () => this._listeners.get(event)?.delete(handler as (payload: unknown) => void)
+    this.#listeners.get(event)!.add(handler as (payload: unknown) => void)
+    return () => this.#listeners.get(event)?.delete(handler as (payload: unknown) => void)
   }
 
   emit<K extends keyof BlockEditorEventMap>(event: K, payload: BlockEditorEventMap[K]): void {
-    const listeners = this._listeners.get(event)
+    const listeners = this.#listeners.get(event)
     if (!listeners) return
     for (const cb of listeners) cb(payload as unknown)
   }
 
   scheduleDataUpdated(id: BlockId): void {
-    if (!this._pending.has(id)) {
-      this._pending.set(id, makeDebounced(
-        () => this._emitDataUpdated(id),
-        this._debounceMs,
-        this._maxWaitMs,
+    if (!this.#pending.has(id)) {
+      this.#pending.set(id, makeDebounced(
+        () => this.#emitDataUpdated(id),
+        this.#debounceMs,
+        this.#maxWaitMs,
       ))
     }
-    this._pending.get(id)!()
+    this.#pending.get(id)!()
   }
 
-  private _emitDataUpdated(id: BlockId): void {
-    this._pending.delete(id)
-    const data = this._getBlockData(id)
+  #emitDataUpdated(id: BlockId): void {
+    this.#pending.delete(id)
+    const data = this.#getBlockData(id)
     if (data) this.emit('blockDataUpdated', data)
   }
 
   flushDataUpdated(id: BlockId): void {
-    const fn = this._pending.get(id)
+    const fn = this.#pending.get(id)
     if (fn) fn.flush()
   }
 
   cancelDataUpdated(id: BlockId): void {
-    const fn = this._pending.get(id)
+    const fn = this.#pending.get(id)
     if (fn) {
       fn.cancel()
-      this._pending.delete(id)
+      this.#pending.delete(id)
     }
   }
 
   flushAll(): void {
-    for (const id of [...this._pending.keys()]) {
+    for (const id of [...this.#pending.keys()]) {
       this.flushDataUpdated(id)
     }
   }
 
   cancelAll(): void {
-    for (const fn of this._pending.values()) fn.cancel()
-    this._pending.clear()
+    for (const fn of this.#pending.values()) fn.cancel()
+    this.#pending.clear()
   }
 }

--- a/src/lib/block-editor/editor/TextEditor.ts
+++ b/src/lib/block-editor/editor/TextEditor.ts
@@ -59,20 +59,20 @@ function findNodeAtOffset(root: Node, targetOffset: number): { node: globalThis.
 // ─── TextEditor ───────────────────────────────────────────────────────────────
 
 export class TextEditor {
-  private _state: Text
-  private _editable: HTMLDivElement
-  private _toolbar: HTMLDivElement
-  private _listeners: Set<(t: Text) => void> = new Set()
-  private _composing = false
+  #state: Text
+  #editable: HTMLDivElement
+  #toolbar: HTMLDivElement
+  #listeners: Set<(t: Text) => void> = new Set()
+  #composing = false
 
-  private _buttons: Map<InlineTypes, HTMLButtonElement> = new Map()
+  #buttons: Map<InlineTypes, HTMLButtonElement> = new Map()
 
   constructor(container: HTMLElement, initial?: Text) {
-    this._state = initial ?? new Text('', [])
+    this.#state = initial ?? new Text('', [])
 
     // Build toolbar
-    this._toolbar = document.createElement('div')
-    this._toolbar.className = 'text-editor-toolbar'
+    this.#toolbar = document.createElement('div')
+    this.#toolbar.className = 'text-editor-toolbar'
 
     const buttonDefs: { type: InlineTypes; icon: Parameters<typeof createElement>[0] }[] = [
       { type: 'Bold', icon: Bold },
@@ -88,92 +88,92 @@ export class TextEditor {
       // Use mousedown + preventDefault to keep focus in editable
       btn.addEventListener('mousedown', (e) => {
         e.preventDefault()
-        this._applyOrRemoveInline(type)
+        this.#applyOrRemoveInline(type)
       })
-      this._toolbar.appendChild(btn)
-      this._buttons.set(type, btn)
+      this.#toolbar.appendChild(btn)
+      this.#buttons.set(type, btn)
     }
 
     // Build editable
-    this._editable = document.createElement('div')
-    this._editable.className = 'text-editor-editable'
-    this._editable.contentEditable = 'true'
+    this.#editable = document.createElement('div')
+    this.#editable.className = 'text-editor-editable'
+    this.#editable.contentEditable = 'true'
 
-    this._editable.addEventListener('input', () => {
-      if (!this._composing) this._handleInput()
+    this.#editable.addEventListener('input', () => {
+      if (!this.#composing) this.#handleInput()
     })
-    this._editable.addEventListener('compositionstart', () => {
-      this._composing = true
+    this.#editable.addEventListener('compositionstart', () => {
+      this.#composing = true
     })
-    this._editable.addEventListener('compositionend', () => {
-      this._composing = false
-      this._handleInput()
+    this.#editable.addEventListener('compositionend', () => {
+      this.#composing = false
+      this.#handleInput()
     })
 
     document.addEventListener('selectionchange', () => {
-      if (document.activeElement === this._editable) {
-        this._updateToolbarState()
+      if (document.activeElement === this.#editable) {
+        this.#updateToolbarState()
       }
     })
 
-    container.appendChild(this._toolbar)
-    container.appendChild(this._editable)
+    container.appendChild(this.#toolbar)
+    container.appendChild(this.#editable)
 
-    this._render()
+    this.#render()
   }
 
   getValue(): Text {
-    return this._state
+    return this.#state
   }
 
   setValue(text: Text): void {
-    this._state = text
-    this._render()
-    this._notify()
+    this.#state = text
+    this.#render()
+    this.#notify()
   }
 
   /** Registers a change listener. Returns an unsubscribe function. */
   onChange(cb: (text: Text) => void): () => void {
-    this._listeners.add(cb)
-    return () => this._listeners.delete(cb)
+    this.#listeners.add(cb)
+    return () => this.#listeners.delete(cb)
   }
 
   destroy(): void {
-    this._toolbar.remove()
-    this._editable.remove()
+    this.#toolbar.remove()
+    this.#editable.remove()
   }
 
   // ─── Private ───────────────────────────────────────────────────────────────
 
-  private _notify(): void {
-    for (const cb of this._listeners) cb(this._state)
+  #notify(): void {
+    for (const cb of this.#listeners) cb(this.#state)
   }
 
-  private _getSelectionOffsets(): { start: number; end: number } | null {
+  #getSelectionOffsets(): { start: number; end: number } | null {
     const sel = window.getSelection()
     if (!sel || sel.rangeCount === 0) return null
 
     const range = sel.getRangeAt(0)
 
     // Guard: selection must be within the editable
-    if (!this._editable.contains(range.startContainer)) return null
+    if (!this.#editable.contains(range.startContainer)) return null
 
-    const start = getCharOffset(this._editable, range.startContainer, range.startOffset)
-    const end = getCharOffset(this._editable, range.endContainer, range.endOffset)
+    const start = getCharOffset(this.#editable, range.startContainer, range.startOffset)
+    const end = getCharOffset(this.#editable, range.endContainer, range.endOffset)
 
     if (start === -1 || end === -1) return null
     return { start, end }
   }
 
-  private _restoreSelection(start: number, end: number): void {
-    if (document.activeElement !== this._editable) return
+  #restoreSelection(start: number, end: number): void {
+    if (document.activeElement !== this.#editable) return
 
     const sel = window.getSelection()
     if (!sel) return
 
     try {
-      const startPos = findNodeAtOffset(this._editable, start)
-      const endPos = findNodeAtOffset(this._editable, end)
+      const startPos = findNodeAtOffset(this.#editable, start)
+      const endPos = findNodeAtOffset(this.#editable, end)
 
       const range = document.createRange()
       range.setStart(startPos.node, startPos.offset)
@@ -186,14 +186,14 @@ export class TextEditor {
     }
   }
 
-  private _render(savedStart?: number, savedEnd?: number): void {
-    const focused = document.activeElement === this._editable
+  #render(savedStart?: number, savedEnd?: number): void {
+    const focused = document.activeElement === this.#editable
 
     // Save selection if not provided
     let start = savedStart ?? 0
     let end = savedEnd ?? 0
     if (focused && savedStart === undefined) {
-      const offsets = this._getSelectionOffsets()
+      const offsets = this.#getSelectionOffsets()
       if (offsets) {
         start = offsets.start
         end = offsets.end
@@ -201,20 +201,20 @@ export class TextEditor {
     }
 
     // Clear and re-render
-    this._editable.innerHTML = ''
-    const nodes = textSerializer.render(this._state)
+    this.#editable.innerHTML = ''
+    const nodes = textSerializer.render(this.#state)
     for (const node of nodes) {
-      this._editable.appendChild(node)
+      this.#editable.appendChild(node)
     }
 
     // Restore selection
     if (focused) {
-      this._restoreSelection(start, end)
+      this.#restoreSelection(start, end)
     }
   }
 
-  private _applyOrRemoveInline(type: InlineTypes): void {
-    const offsets = this._getSelectionOffsets()
+  #applyOrRemoveInline(type: InlineTypes): void {
+    const offsets = this.#getSelectionOffsets()
     if (!offsets) return
 
     const { start, end } = offsets
@@ -223,47 +223,47 @@ export class TextEditor {
     if (start === end) return
 
     // Guard against out-of-range (can happen with empty text)
-    const textLen = this._state.text.length
+    const textLen = this.#state.text.length
     if (start < 0 || end > textLen || start >= end) return
 
-    const toggled = this._state.isToggled(type, start, end)
-    this._state = toggled
-      ? this._state.removeInline(type, start, end)
-      : this._state.addInline(type, start, end)
+    const toggled = this.#state.isToggled(type, start, end)
+    this.#state = toggled
+      ? this.#state.removeInline(type, start, end)
+      : this.#state.addInline(type, start, end)
 
-    this._render(start, end)
-    this._updateToolbarState()
-    this._notify()
+    this.#render(start, end)
+    this.#updateToolbarState()
+    this.#notify()
   }
 
-  private _handleInput(): void {
-    const offsets = this._getSelectionOffsets()
+  #handleInput(): void {
+    const offsets = this.#getSelectionOffsets()
     const start = offsets?.start ?? 0
     const end = offsets?.end ?? 0
 
     requestAnimationFrame(() => {
-      const nodes = Array.from(this._editable.childNodes)
-      this._state = textSerializer.parse(nodes)
+      const nodes = Array.from(this.#editable.childNodes)
+      this.#state = textSerializer.parse(nodes)
 
       // Re-render to normalize DOM (avoids browser-injected divs/brs accumulating)
-      this._render(start, end)
-      this._notify()
+      this.#render(start, end)
+      this.#notify()
     })
   }
 
-  private _updateToolbarState(): void {
-    const offsets = this._getSelectionOffsets()
+  #updateToolbarState(): void {
+    const offsets = this.#getSelectionOffsets()
 
-    for (const [type, btn] of this._buttons) {
+    for (const [type, btn] of this.#buttons) {
       let active = false
 
       if (offsets && offsets.start !== offsets.end) {
-        const textLen = this._state.text.length
+        const textLen = this.#state.text.length
         const start = Math.max(0, offsets.start)
         const end = Math.min(textLen, offsets.end)
         if (start < end) {
           try {
-            active = this._state.isToggled(type, start, end)
+            active = this.#state.isToggled(type, start, end)
           } catch {
             active = false
           }


### PR DESCRIPTION
## Summary
- Replaces all `private _field` / `private _method` declarations with JavaScript-native `#field` / `#method` across the block editor library (4 files, ~41 members renamed)
- Adds a **Private Fields** rule section to `blockEditor.md` documenting the convention: use `#` for runtime enforcement, `protected` for subclass access, never `_` prefix
- Updates the standard component shape example in the rules to use `#` syntax

## Test plan
- [x] `pnpm vitest run` passes with 0 failures
- [x] `pnpm check` reports 0 type errors
- [x] All `private _` patterns are gone from `src/lib/block-editor/editor/`
- [x] Public API surface (`index.ts`) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)