### PR TITLE
refactor: replace BlocksChange union with frozen value-type classes

### DIFF
--- a/src/components/event-log-panel.svelte
+++ b/src/components/event-log-panel.svelte
@@ -2,13 +2,13 @@
   import CodePreview from './code-preview.svelte'
   import RelativeTimestamp from './relative-timestamp.svelte'
   import { popup } from './popup-attachment'
-  import type { BlockEditorEventMap } from '$lib/block-editor'
+  import type { BlockEditorEventDtoMap } from '$lib/block-editor'
   import { Trash2Icon } from '@lucide/svelte'
 
-  export type LogEntry<T extends keyof BlockEditorEventMap = keyof BlockEditorEventMap> = {
+  export type LogEntry<T extends keyof BlockEditorEventDtoMap = keyof BlockEditorEventDtoMap> = {
     timestamp: number
     name: T
-    payload: BlockEditorEventMap[T]
+    payload: BlockEditorEventDtoMap[T]
   }
 
   let {
@@ -17,7 +17,7 @@
     entries?: LogEntry[]
   } = $props()
 
-  const eventColors: Record<keyof BlockEditorEventMap, string> = {
+  const eventColors: Record<keyof BlockEditorEventDtoMap, string> = {
     blockCreated:     'text-emerald-600 dark:text-emerald-400',
     blockDataUpdated: 'text-blue-600 dark:text-blue-400',
     blockRemoved:     'text-rose-600 dark:text-rose-400',
@@ -25,7 +25,7 @@
     selectionChange:  'text-(--fg) opacity-50',
   }
 
-  function colorFor(name: keyof BlockEditorEventMap): string {
+  function colorFor(name: keyof BlockEditorEventDtoMap): string {
     return eventColors[name]
   }
 </script>

--- a/src/lib/block-editor/blocks/blocks.test.ts
+++ b/src/lib/block-editor/blocks/blocks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { Blocks, Block, BlockOffset, BlockRange } from './blocks'
+import { Blocks, Block, BlockOffset, BlockRange, BlockMoved, BlockRemoved, BlockAdded, BlockDataChanged } from './blocks'
 import { Text } from '../text/text'
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -1059,27 +1059,30 @@ describe('Blocks.diff', () => {
     const b2 = b1.update('a', new Text('changed', []))
     const changes = Blocks.diff(b1, b2)
     expect(changes).toHaveLength(1)
-    expect(changes[0]).toMatchObject({ type: 'dataChanged', id: 'a' })
+    expect(changes[0]).toBeInstanceOf(BlockDataChanged)
+    expect(changes[0]).toMatchObject({ id: 'a' })
   })
 
   it('detects removed blocks', () => {
     const b1 = Blocks.from([dto('a'), dto('b'), dto('c')])
     const b2 = b1.delete('b')
     const changes = Blocks.diff(b1, b2)
-    expect(changes).toContainEqual({ type: 'removed', id: 'b' })
+    expect(changes).toContainEqual(new BlockRemoved('b'))
     // 'a' is unchanged
     expect(changes).not.toContainEqual(expect.objectContaining({ id: 'a' }))
     // 'c' prevSibling changed from 'b' → 'a', so it gets a moved entry
-    expect(changes).toContainEqual(expect.objectContaining({ type: 'moved', id: 'c' }))
+    expect(changes).toContainEqual(expect.objectContaining({ id: 'c' }))
+    expect(changes.find(c => c instanceof BlockMoved && c.id === 'c')).toBeDefined()
   })
 
   it('detects moved blocks when parent changes (indent)', () => {
     const b1 = Blocks.from([dto('a'), dto('b')])
     const b2 = b1.indent('b', 'b')  // b becomes child of a
     const changes = Blocks.diff(b1, b2)
-    const bMoved = changes.find(c => c.type === 'moved' && c.id === 'b')
+    const bMoved = changes.find(c => c instanceof BlockMoved && c.id === 'b')
     expect(bMoved).toBeDefined()
-    expect(bMoved).toMatchObject({ type: 'moved', id: 'b', parentBlockId: 'a', previousBlockId: null })
+    expect(bMoved).toBeInstanceOf(BlockMoved)
+    expect(bMoved).toMatchObject({ id: 'b', parentBlockId: 'a', previousBlockId: null })
   })
 
   it('detects moved blocks when prevSibling changes', () => {
@@ -1088,16 +1091,17 @@ describe('Blocks.diff', () => {
     const b1 = Blocks.from([dto('a'), dto('b')])
     const b2 = b1.splitAt('a', 0, 'x')  // flat: [a, x, b]
     const changes = Blocks.diff(b1, b2)
-    const bMoved = changes.find(c => c.type === 'moved' && c.id === 'b')
+    const bMoved = changes.find(c => c instanceof BlockMoved && c.id === 'b')
     expect(bMoved).toBeDefined()
-    expect(bMoved).toMatchObject({ type: 'moved', id: 'b', previousBlockId: 'x', parentBlockId: null })
+    expect(bMoved).toBeInstanceOf(BlockMoved)
+    expect(bMoved).toMatchObject({ id: 'b', previousBlockId: 'x', parentBlockId: null })
   })
 
   it('reports added for blocks absent from oldBlocks (splitAt)', () => {
     const b1 = Blocks.from([dto('a', 'hello')])
     const b2 = b1.splitAt('a', 3, 'new')  // [a='hel', new='lo']
     const changes = Blocks.diff(b1, b2)
-    const addedChange = changes.find(c => c.type === 'added' && c.id === 'new')
+    const addedChange = changes.find(c => c instanceof BlockAdded && c.id === 'new')
     expect(addedChange).toBeDefined()
   })
 
@@ -1105,9 +1109,9 @@ describe('Blocks.diff', () => {
     const b1 = Blocks.from([dto('a', 'hello'), dto('b')])
     const b2 = b1.splitAt('a', 3, 'new')  // flat: [a='hel', new='lo', b]
     const changes = Blocks.diff(b1, b2)
-    const addedChange = changes.find(c => c.type === 'added' && c.id === 'new')
+    const addedChange = changes.find(c => c instanceof BlockAdded && c.id === 'new')
+    expect(addedChange).toBeInstanceOf(BlockAdded)
     expect(addedChange).toMatchObject({
-      type: 'added',
       id: 'new',
       data: { text: 'lo', inline: [] },
       previousBlockId: 'a',
@@ -1120,9 +1124,9 @@ describe('Blocks.diff', () => {
     // Insert a new block after 'b' at same indent (root level)
     const b2 = b1.addAfter('b', { id: 'x', data: new Text('hi', []) })
     const changes = Blocks.diff(b1, b2)
-    const addedChange = changes.find(c => c.type === 'added' && c.id === 'x')
+    const addedChange = changes.find(c => c instanceof BlockAdded && c.id === 'x')
+    expect(addedChange).toBeInstanceOf(BlockAdded)
     expect(addedChange).toMatchObject({
-      type: 'added',
       id: 'x',
       previousBlockId: 'b',
       parentBlockId: null,
@@ -1133,24 +1137,25 @@ describe('Blocks.diff', () => {
     const b1 = Blocks.from([dto('a', 'hello'), dto('b', 'world')])
     const b2 = b1.update('a', new Text('changed', []))
     const changes = Blocks.diff(b1, b2)
-    const dataChanged = changes.find(c => c.type === 'dataChanged' && c.id === 'a')
+    const dataChanged = changes.find(c => c instanceof BlockDataChanged && c.id === 'a')
     expect(dataChanged).toBeDefined()
-    expect(dataChanged).toMatchObject({ type: 'dataChanged', id: 'a', data: { text: 'changed', inline: [] } })
+    expect(dataChanged).toBeInstanceOf(BlockDataChanged)
+    expect(dataChanged).toMatchObject({ id: 'a', data: { text: 'changed', inline: [] } })
   })
 
   it('reports no dataChanged when data is identical', () => {
     const b1 = Blocks.from([dto('a', 'hello'), dto('b', 'world')])
     const changes = Blocks.diff(b1, b1)
-    expect(changes.filter(c => c.type === 'dataChanged')).toHaveLength(0)
+    expect(changes.filter(c => c instanceof BlockDataChanged)).toHaveLength(0)
   })
 
   it('reports dataChanged only for blocks whose content changed', () => {
     const b1 = Blocks.from([dto('a', 'hello'), dto('b', 'world')])
     const b2 = b1.update('b', new Text('updated', []))
     const changes = Blocks.diff(b1, b2)
-    expect(changes.filter(c => c.type === 'dataChanged')).toHaveLength(1)
-    expect(changes.find(c => c.type === 'dataChanged' && c.id === 'b')).toBeDefined()
-    expect(changes.find(c => c.type === 'dataChanged' && c.id === 'a')).toBeUndefined()
+    expect(changes.filter(c => c instanceof BlockDataChanged)).toHaveLength(1)
+    expect(changes.find(c => c instanceof BlockDataChanged && c.id === 'b')).toBeDefined()
+    expect(changes.find(c => c instanceof BlockDataChanged && c.id === 'a')).toBeUndefined()
   })
 })
 

--- a/src/lib/block-editor/blocks/blocks.ts
+++ b/src/lib/block-editor/blocks/blocks.ts
@@ -45,11 +45,35 @@ export class BlockRange {
   }
 }
 
-export type BlocksChange =
-  | { type: 'moved';        id: BlockId; previousBlockId: BlockId | null; parentBlockId: BlockId | null }
-  | { type: 'removed';      id: BlockId }
-  | { type: 'added';        id: BlockId; data: TextDto; previousBlockId: BlockId | null; parentBlockId: BlockId | null }
-  | { type: 'dataChanged';  id: BlockId; data: TextDto }
+export class BlockMoved {
+  constructor(
+    readonly id: BlockId,
+    readonly previousBlockId: BlockId | null,
+    readonly parentBlockId: BlockId | null,
+  ) { Object.freeze(this) }
+}
+
+export class BlockRemoved {
+  constructor(readonly id: BlockId) { Object.freeze(this) }
+}
+
+export class BlockAdded {
+  constructor(
+    readonly id: BlockId,
+    readonly data: TextDto,
+    readonly previousBlockId: BlockId | null,
+    readonly parentBlockId: BlockId | null,
+  ) { Object.freeze(this) }
+}
+
+export class BlockDataChanged {
+  constructor(
+    readonly id: BlockId,
+    readonly data: TextDto,
+  ) { Object.freeze(this) }
+}
+
+export type BlocksChange = BlockMoved | BlockRemoved | BlockAdded | BlockDataChanged
 
 // ─── Internal types ────────────────────────────────────────────────────────────
 
@@ -299,7 +323,7 @@ export class Blocks {
 
     for (const b of oldBlocks.#blocks) {
       if (!newIds.has(b.id)) {
-        changes.push({ type: 'removed', id: b.id })
+        changes.push(new BlockRemoved(b.id))
       }
     }
 
@@ -308,13 +332,12 @@ export class Blocks {
         // New block — report as added
         const newPrev = newBlocks.prevSibling(b.id)
         const newParent = newBlocks.parent(b.id)
-        changes.push({
-          type: 'added',
-          id: b.id,
-          data: { text: b.data.text, inline: [...b.data.inline] as InlineDto[] },
-          previousBlockId: newPrev,
-          parentBlockId: newParent,
-        })
+        changes.push(new BlockAdded(
+          b.id,
+          { text: b.data.text, inline: [...b.data.inline] as InlineDto[] },
+          newPrev,
+          newParent,
+        ))
         continue
       }
 
@@ -323,16 +346,15 @@ export class Blocks {
       const oldPrev = oldBlocks.prevSibling(b.id)
       const newPrev = newBlocks.prevSibling(b.id)
       if (oldParent !== newParent || oldPrev !== newPrev) {
-        changes.push({ type: 'moved', id: b.id, previousBlockId: newPrev, parentBlockId: newParent })
+        changes.push(new BlockMoved(b.id, newPrev, newParent))
       }
 
       const oldData = oldDataMap.get(b.id)!
       if (!oldData.equals(b.data)) {
-        changes.push({
-          type: 'dataChanged',
-          id: b.id,
-          data: { text: b.data.text, inline: [...b.data.inline] as InlineDto[] },
-        })
+        changes.push(new BlockDataChanged(
+          b.id,
+          { text: b.data.text, inline: [...b.data.inline] as InlineDto[] },
+        ))
       }
     }
 

--- a/src/lib/block-editor/editor/BlockEditor.test.ts
+++ b/src/lib/block-editor/editor/BlockEditor.test.ts
@@ -4,7 +4,7 @@ import { BlockEditorWithToolbar } from './BlockEditorWithToolbar'
 import { Blocks, Block } from '../blocks/blocks'
 import { type InlineTypes } from '../text/text'
 import { BLOCK_EDITOR_EVENT_NAMES } from './events'
-import type { BlockDataUpdatedEvent } from './events'
+import type { BlockDataUpdatedEventDto } from './events'
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -240,7 +240,7 @@ describe('blockDataUpdated debouncing', () => {
   it('does not fire immediately after input', () => {
     const container = makeContainer()
     const editor = new BlockEditor(container, Blocks.from([dto('a', 'Hello')]))
-    const events: BlockDataUpdatedEvent[] = []
+    const events: BlockDataUpdatedEventDto[] = []
     editor.addEventListener('blockDataUpdated', (e) => events.push(e))
 
     getEditable(container).focus()
@@ -253,7 +253,7 @@ describe('blockDataUpdated debouncing', () => {
   it('fires after debounce delay', () => {
     const container = makeContainer()
     const editor = new BlockEditor(container, Blocks.from([dto('a', 'Hello')]), { dataUpdateDebounceMs: 1000 })
-    const events: BlockDataUpdatedEvent[] = []
+    const events: BlockDataUpdatedEventDto[] = []
     editor.addEventListener('blockDataUpdated', (e) => events.push(e))
 
     getEditable(container).focus()
@@ -271,7 +271,7 @@ describe('blockDataUpdated debouncing', () => {
       dataUpdateDebounceMs: 1000,
       dataUpdateMaxWaitMs: 3000,
     })
-    const events: BlockDataUpdatedEvent[] = []
+    const events: BlockDataUpdatedEventDto[] = []
     editor.addEventListener('blockDataUpdated', (e) => events.push(e))
 
     getEditable(container).focus()
@@ -290,7 +290,7 @@ describe('blockDataUpdated debouncing', () => {
   it('blur flushes pending synchronously', () => {
     const container = makeContainer()
     const editor = new BlockEditor(container, Blocks.from([dto('a', 'Hello')]))
-    const events: BlockDataUpdatedEvent[] = []
+    const events: BlockDataUpdatedEventDto[] = []
     editor.addEventListener('blockDataUpdated', (e) => events.push(e))
 
     getEditable(container).focus()
@@ -305,7 +305,7 @@ describe('blockDataUpdated debouncing', () => {
   it('unsubscribe stops delivery', () => {
     const container = makeContainer()
     const editor = new BlockEditor(container, Blocks.from([dto('a', 'Hello')]), { dataUpdateDebounceMs: 100 })
-    const events: BlockDataUpdatedEvent[] = []
+    const events: BlockDataUpdatedEventDto[] = []
     const unsub = editor.addEventListener('blockDataUpdated', (e) => events.push(e))
     unsub()
 

--- a/src/lib/block-editor/editor/BlockEditor.ts
+++ b/src/lib/block-editor/editor/BlockEditor.ts
@@ -1,8 +1,8 @@
 import { Text, type InlineTypes, type InlineDto } from '../text/text'
 import { textSerializer } from '../text/serializer'
-import { Blocks, type BlockId, BlockOffset, BlockRange } from '../blocks/blocks'
+import { Blocks, type BlockId, BlockOffset, BlockRange, BlockDataChanged, BlockAdded, BlockRemoved, BlockMoved } from '../blocks/blocks'
 import { blocksSerializer } from '../blocks/serializer'
-import type { BlockEditorEventMap, BlockEditorOptions, BlockSelection } from './events'
+import type { BlockEditorEventDtoMap, BlockEditorOptions, BlockSelection } from './events'
 import { BlockEventEmitter } from './BlockEventEmitter'
 import './block-editor.css'
 
@@ -169,9 +169,9 @@ export class BlockEditor {
   }
 
   /** Registers a typed event listener. Returns an unsubscribe function. */
-  addEventListener<K extends keyof BlockEditorEventMap>(
+  addEventListener<K extends keyof BlockEditorEventDtoMap>(
     event: K,
-    handler: (payload: BlockEditorEventMap[K]) => void,
+    handler: (payload: BlockEditorEventDtoMap[K]) => void,
   ): () => void {
     return this.#emitter.addEventListener(event, handler)
   }
@@ -267,22 +267,22 @@ export class BlockEditor {
 
     // Emit in a stable semantic order: dataChanged → added → removed → moved
     for (const change of changes) {
-      if (change.type === 'dataChanged') {
+      if (change instanceof BlockDataChanged) {
         this.#emitter.emit('blockDataUpdated', { id: change.id, data: change.data })
       }
     }
     for (const change of changes) {
-      if (change.type === 'added') {
+      if (change instanceof BlockAdded) {
         this.#emitter.emit('blockCreated', { id: change.id, data: change.data, previousBlockId: change.previousBlockId, parentBlockId: change.parentBlockId })
       }
     }
     for (const change of changes) {
-      if (change.type === 'removed') {
+      if (change instanceof BlockRemoved) {
         this.#emitter.emit('blockRemoved', { id: change.id })
       }
     }
     for (const change of changes) {
-      if (change.type === 'moved') {
+      if (change instanceof BlockMoved) {
         this.#emitter.emit('blockMoved', { id: change.id, previousBlockId: change.previousBlockId, parentBlockId: change.parentBlockId })
       }
     }

--- a/src/lib/block-editor/editor/BlockEditorWithToolbar.ts
+++ b/src/lib/block-editor/editor/BlockEditorWithToolbar.ts
@@ -1,7 +1,7 @@
 import { type InlineTypes, type InlineDtoMap } from '../text/text'
 import { Blocks } from '../blocks/blocks'
 import { BlockEditor } from './BlockEditor'
-import type { BlockEditorEventMap, BlockEditorOptions } from './events'
+import type { BlockEditorEventDtoMap, BlockEditorOptions } from './events'
 import { createElement, Bold, Italic, Underline, IndentIncrease, IndentDecrease } from 'lucide'
 import './block-editor-toolbar.css'
 
@@ -97,9 +97,9 @@ export class BlockEditorWithToolbar {
     this.#editor.setValue(blocks)
   }
 
-  addEventListener<K extends keyof BlockEditorEventMap>(
+  addEventListener<K extends keyof BlockEditorEventDtoMap>(
     event: K,
-    handler: (payload: BlockEditorEventMap[K]) => void,
+    handler: (payload: BlockEditorEventDtoMap[K]) => void,
   ): () => void {
     return this.#editor.addEventListener(event, handler)
   }

--- a/src/lib/block-editor/editor/BlockEventEmitter.ts
+++ b/src/lib/block-editor/editor/BlockEventEmitter.ts
@@ -1,16 +1,16 @@
 import type { BlockId } from '../blocks/blocks'
-import type { BlockEditorEventMap, BlockDataUpdatedEvent } from './events'
+import type { BlockEditorEventDtoMap, BlockDataUpdatedEventDto } from './events'
 import { makeDebounced, type DebouncedFn } from './debounce'
 
 export class BlockEventEmitter {
-  #listeners: Map<keyof BlockEditorEventMap, Set<(payload: unknown) => void>> = new Map()
+  #listeners: Map<keyof BlockEditorEventDtoMap, Set<(payload: unknown) => void>> = new Map()
   #pending: Map<BlockId, DebouncedFn> = new Map()
-  #getBlockData: (id: BlockId) => BlockDataUpdatedEvent | null
+  #getBlockData: (id: BlockId) => BlockDataUpdatedEventDto | null
   #debounceMs: number
   #maxWaitMs: number
 
   constructor(
-    getBlockData: (id: BlockId) => BlockDataUpdatedEvent | null,
+    getBlockData: (id: BlockId) => BlockDataUpdatedEventDto | null,
     opts: { debounceMs: number; maxWaitMs: number },
   ) {
     this.#getBlockData = getBlockData
@@ -18,9 +18,9 @@ export class BlockEventEmitter {
     this.#maxWaitMs = opts.maxWaitMs
   }
 
-  addEventListener<K extends keyof BlockEditorEventMap>(
+  addEventListener<K extends keyof BlockEditorEventDtoMap>(
     event: K,
-    handler: (payload: BlockEditorEventMap[K]) => void,
+    handler: (payload: BlockEditorEventDtoMap[K]) => void,
   ): () => void {
     if (!this.#listeners.has(event)) {
       this.#listeners.set(event, new Set())
@@ -29,7 +29,7 @@ export class BlockEventEmitter {
     return () => this.#listeners.get(event)?.delete(handler as (payload: unknown) => void)
   }
 
-  emit<K extends keyof BlockEditorEventMap>(event: K, payload: BlockEditorEventMap[K]): void {
+  emit<K extends keyof BlockEditorEventDtoMap>(event: K, payload: BlockEditorEventDtoMap[K]): void {
     const listeners = this.#listeners.get(event)
     if (!listeners) return
     for (const cb of listeners) cb(payload as unknown)

--- a/src/lib/block-editor/editor/events.ts
+++ b/src/lib/block-editor/editor/events.ts
@@ -3,17 +3,17 @@ import type { TextDto } from '../text/text'
 import { BlockOffset, BlockRange } from '../blocks/blocks'
 
 export type BlockSelection        = BlockOffset | BlockRange
-export type BlockCreatedEvent     = { id: BlockId; data: TextDto; previousBlockId: BlockId | null; parentBlockId: BlockId | null }
-export type BlockDataUpdatedEvent = { id: BlockId; data: TextDto }
-export type BlockRemovedEvent     = { id: BlockId }
-export type BlockMovedEvent       = { id: BlockId; previousBlockId: BlockId | null; parentBlockId: BlockId | null }
+export type BlockCreatedEventDto     = { id: BlockId; data: TextDto; previousBlockId: BlockId | null; parentBlockId: BlockId | null }
+export type BlockDataUpdatedEventDto = { id: BlockId; data: TextDto }
+export type BlockRemovedEventDto     = { id: BlockId }
+export type BlockMovedEventDto       = { id: BlockId; previousBlockId: BlockId | null; parentBlockId: BlockId | null }
 
-export type BlockEditorEventMap = {
+export type BlockEditorEventDtoMap = {
   selectionChange:  BlockSelection | null
-  blockCreated:     BlockCreatedEvent
-  blockDataUpdated: BlockDataUpdatedEvent
-  blockRemoved:     BlockRemovedEvent
-  blockMoved:       BlockMovedEvent
+  blockCreated:     BlockCreatedEventDto
+  blockDataUpdated: BlockDataUpdatedEventDto
+  blockRemoved:     BlockRemovedEventDto
+  blockMoved:       BlockMovedEventDto
 }
 
 export interface BlockEditorOptions {
@@ -24,11 +24,11 @@ export interface BlockEditorOptions {
 
 export const BLOCK_EDITOR_EVENT_NAMES = [
   'selectionChange', 'blockCreated', 'blockDataUpdated', 'blockRemoved', 'blockMoved',
-] as const satisfies ReadonlyArray<keyof BlockEditorEventMap>
+] as const satisfies ReadonlyArray<keyof BlockEditorEventDtoMap>
 
 // Compile-time exhaustiveness checks: both directions must hold
-type _AllIncluded = keyof BlockEditorEventMap extends (typeof BLOCK_EDITOR_EVENT_NAMES)[number] ? true : never
-type _NoExtras    = (typeof BLOCK_EDITOR_EVENT_NAMES)[number] extends keyof BlockEditorEventMap ? true : never
+type _AllIncluded = keyof BlockEditorEventDtoMap extends (typeof BLOCK_EDITOR_EVENT_NAMES)[number] ? true : never
+type _NoExtras    = (typeof BLOCK_EDITOR_EVENT_NAMES)[number] extends keyof BlockEditorEventDtoMap ? true : never
 
 // Re-export so consumers can do instanceof checks
 export { BlockOffset, BlockRange }

--- a/src/lib/block-editor/index.ts
+++ b/src/lib/block-editor/index.ts
@@ -1,14 +1,14 @@
-export { Block, Blocks, BlockOffset, BlockRange, type BlockId, type BlocksChange } from "./blocks/blocks"
+export { Block, Blocks, BlockOffset, BlockRange, BlockMoved, BlockRemoved, BlockAdded, BlockDataChanged, type BlockId, type BlocksChange } from "./blocks/blocks"
 export { BlockEditor } from "./editor/BlockEditor";
 export { BlockEditorWithToolbar } from "./editor/BlockEditorWithToolbar";
 export { BLOCK_EDITOR_EVENT_NAMES } from "./editor/events"
 export type {
   BlockEditorOptions,
-  BlockEditorEventMap,
-  BlockCreatedEvent,
-  BlockDataUpdatedEvent,
-  BlockRemovedEvent,
-  BlockMovedEvent,
+  BlockEditorEventDtoMap,
+  BlockCreatedEventDto,
+  BlockDataUpdatedEventDto,
+  BlockRemovedEventDto,
+  BlockMovedEventDto,
   BlockSelection,
 } from "./editor/events"
 export type { TextDto } from "./text/text"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Blocks, Block, BlockEditorWithToolbar, BLOCK_EDITOR_EVENT_NAMES } from "$lib/block-editor";
-    import type { BlockSelection, BlockEditorEventMap } from "$lib/block-editor";
+    import type { BlockSelection, BlockEditorEventDtoMap } from "$lib/block-editor";
     import ResizableLayout from "../components/resizable-layout.svelte";
     import CollapsibleSection from "../components/collapsible-section.svelte";
     import CodePreview from "../components/code-preview.svelte";
@@ -36,7 +36,7 @@
 
     let selection = $state<BlockSelection | null>(null);
     let blocks = $state(initialBlocks.blocks);
-    const log = localState<LogEntry<keyof BlockEditorEventMap>[]>('event-log', []);
+    const log = localState<LogEntry<keyof BlockEditorEventDtoMap>[]>('event-log', []);
 
     const selectionOpen = localState('inspector-selection', true)
     const stateOpen     = localState('inspector-state',     true)


### PR DESCRIPTION
## Summary
- Replace the `{ type: '...' }` discriminated union for `BlocksChange` with four `Object.freeze`d value-type classes: `BlockMoved`, `BlockRemoved`, `BlockAdded`, `BlockDataChanged`
- Discrimination moves from `change.type === 'moved'` to `change instanceof BlockMoved`, aligning with the existing `Block`, `BlockOffset`, `BlockRange` pattern
- Rename all event payload types with a `Dto` suffix: `BlockCreatedEventDto`, `BlockDataUpdatedEventDto`, `BlockRemovedEventDto`, `BlockMovedEventDto`, and `BlockEditorEventDtoMap`
- Export all four new classes from `index.ts`
- Update all tests and the demo app to use the new names

## Test plan
- [ ] All 357 tests pass (`pnpm vitest run`)
- [ ] No TypeScript errors (`pnpm check`)
- [ ] `instanceof` checks in `BlockEditor.#emitEvents()` correctly discriminate each change type
- [ ] `BlockDataChanged` uses `Text.equals()` from the upstream `Text` model

🤖 Generated with [Claude Code](https://claude.com/claude-code)