### PR TITLE
docs: trim inferable content from Claude rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,35 +1,11 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Repository Map
 
 - `src/lib/block-editor/` — editor library (pure vanilla TypeScript, no framework)
 - `src/routes/` — SvelteKit demo application (Svelte 5)
 - `src/components/` — shared Svelte components used by the demo
-
-## Commands
-
-```bash
-pnpm dev          # start SvelteKit dev server
-pnpm build        # build the app
-pnpm check        # run svelte-check
-```
-
-Run all tests once (CI style):
-```bash
-pnpm vitest run
-```
-
-Run a single test file:
-```bash
-pnpm vitest run src/lib/block-editor/text/text.test.ts
-```
-
-Watch mode (during development):
-```bash
-pnpm vitest
-```
 
 ## Development Workflow
 
@@ -52,40 +28,6 @@ Use small, atomic commits. Follow the commit message and PR description conventi
 **Prefer build-time errors over runtime errors.** Use TypeScript's type system to make invalid states unrepresentable. Favour exhaustive `switch` statements (with a `never` default), discriminated unions, and strict types so that mistakes are caught by `tsc` or tests — not at runtime in production.
 
 **Use the `frontend-design` skill** when building or significantly redesigning UI components, pages, or layouts in the demo application. Invoke it via the Skill tool before writing Svelte/CSS code for any non-trivial UI work.
-
-## Feature Worktrees
-
-**Every new feature must be developed in a dedicated git worktree** — never directly on `master`. When starting a feature, create a worktree on a new branch:
-
-```bash
-git worktree add .claude/worktrees/<branch-name> -b <branch-name>
-```
-
-Work entirely within that worktree, then remove it after the PR is merged:
-
-```bash
-git worktree remove .claude/worktrees/<branch-name>
-git branch -d <branch-name>
-```
-
-## Pull Request Workflow
-
-**Use the `/create-pr` skill** to automate the full PR creation flow. It will:
-
-1. Ensure all commits on the feature branch are GPG-signed — re-signs any unsigned commits with:
-   ```bash
-   git rebase --exec "git commit --amend --no-edit -S" origin/master
-   ```
-2. Fetch and rebase the branch on the latest `origin/master` (with signing).
-3. Force-push with `--force-with-lease`.
-4. Create the PR on GitHub using `gh pr create`.
-5. Open the PR URL in the browser with `open <pr-url>`.
-
-**GPG signing is required.** Branch protection on `master` enforces verified signatures. The signing key is already configured (`commit.gpgsign = true`, key `CD42639745A71184`). To re-sign all commits on a branch manually:
-
-```bash
-git rebase --exec "git commit --amend --no-edit -S" origin/master
-```
 
 ## Area-Specific Rules
 

--- a/.claude/rules/blockEditor.md
+++ b/.claude/rules/blockEditor.md
@@ -1,13 +1,5 @@
 # Block Editor Library
 
-## File Structure
-
-- `src/lib/block-editor/text/` — Text model and serializer
-- `src/lib/block-editor/blocks/` — Block model and serializer
-- `src/lib/block-editor/editor/` — UI components (TextEditor, BlockEditor, BlockEditorWithToolbar)
-- `src/lib/block-editor/index.ts` — public API; all new exports must be added here
-- Tests live alongside source files as `*.test.ts`
-
 ## Boundary Rule
 
 The library is **pure vanilla TypeScript** — no Svelte, no framework, no `$lib` imports. It must be usable outside of SvelteKit. Never import from `src/routes/` or `src/components/`.
@@ -31,59 +23,15 @@ import './text-editor.css'
 
 Do not inject styles via JavaScript or use inline `style` attributes for anything beyond dynamic values.
 
-## Testing
-
-- Tests live alongside source: `text.ts` → `text.test.ts`, `serializer.ts` → `serializer.test.ts`
-- Test the model and serializer logic — inputs, outputs, edge cases
-- Do not test DOM rendering directly; test the data transformations that drive it
-- Run a single file: `pnpm vitest run src/lib/block-editor/text/text.test.ts`
-
 ## Private Fields
 
-Use **JavaScript native `#` private fields** for all private class members. Do not use TypeScript's `private` keyword or the `_` prefix convention.
+Use **JavaScript native `#` private fields** for all private class members. Do not use TypeScript's `private` keyword or the `_` prefix convention. Use `protected` for subclass-accessible members.
 
-- `#` fields are enforced at **runtime** — they cannot be bypassed via bracket notation, `Object.keys`, JSON serialization, or Proxy.
-- TypeScript's `private` keyword is compile-time only; the field is a plain public property at runtime.
-- The `_` prefix is a legacy convention with no enforcement — actively discouraged by the Google TypeScript Style Guide and the TypeScript team.
-- For members that subclasses must access, use TypeScript's `protected` keyword (no `#` equivalent exists).
 - When accessing a private **static** `#` field, always reference it via the class name — never via `this` — to avoid a `TypeError` when the method is inherited.
 
 ## Component Patterns
 
-All UI components follow a **class-based pattern** — no Web Components, no framework.
-
-**Do not use Web Components (Custom Elements).** They add global registration overhead, Shadow DOM complexity, and attribute-only API limitations. ProseMirror and CodeMirror use the same class-based approach.
-
-### Standard component shape
-
-```typescript
-class MyComponent {
-  #root: HTMLElement
-  #onFoo = () => { /* arrow fn stored as field for removeEventListener */ }
-
-  constructor(container: HTMLElement, opts: MyOptions) {
-    // Build DOM, attach listeners, call #render()
-    document.addEventListener('selectionchange', this.#onFoo)
-  }
-
-  getValue(): State { ... }
-  setValue(state: State): void { this.#state = state; this.#render() }
-  onChange(cb: (state: State) => void): () => void { /* return unsubscribe fn */ }
-
-  destroy(): void {
-    this.#root.remove()
-    document.removeEventListener('selectionchange', this.#onFoo) // must remove global listeners
-  }
-
-  #render(): void { /* idempotent DOM sync — never recreate; only patch */ }
-}
-```
-
-**Lifecycle rules:**
-- `constructor` — create DOM, register listeners, call `#render()`
-- `#render()` — private, idempotent, projects state → DOM; never recreate chrome, only patch (toggle classes/attributes)
-- `destroy()` — remove created DOM, **always detach global listeners** (`document`, `window`) stored as private arrow-function fields
-- Upward communication via subscription (`onChange(cb): () => void`) — fully type-safe, no `CustomEvent` dispatch
+All UI components follow a **class-based pattern**.
 
 **Re-rendering rules:**
 - State flows one way: event → derive new state → `_render()` → notify listeners
@@ -91,61 +39,17 @@ class MyComponent {
 - For the rich-text area: full serializer re-render is correct (serializer owns the content)
 - For future block lists: use key-based reconciliation or `morphdom` rather than full replacement
 
-## Architecture
+## Public API
 
-### 1. Text Model — `src/lib/block-editor/text/text.ts`
+All classes and types intended for consumers must be exported from `index.ts`.
 
-Immutable value object (`Text`) representing a string with typed inline annotations (`Bold`, `Italic`, `Underline`). All invariants are enforced at construction time:
-
-- Same-type inlines never overlap or touch (merge semantics in `addInline`).
-- All ranges are bounded: `0 ≤ start < end ≤ text.length`.
-- Inlines are always sorted (start asc, end desc).
-
-Key methods: `addInline`, `removeInline`, `isToggled`. Every mutating method returns a new `Text` instance.
+## Inline Types
 
 `InlineDtoMap` is a discriminated union — **adding a new inline type requires updating `InlineDtoMap`**, which propagates exhaustiveness errors automatically to the serializer and any other exhaustive switch.
 
-### 2. Text Serializer — `src/lib/block-editor/text/serializer.ts`
+## Blocks: Domain-Logic Boundary
 
-Bidirectional conversion between `Text` and arrays of DOM nodes.
-
-- **Render:** `buildSegments()` splits text into contiguous segments sharing the same active inline stack, then `renderSegments()` recursively wraps them in the correct tags. Nesting order: longer (outer) inlines wrap shorter (inner) ones.
-- **Parse:** `parseNode()` recursively walks DOM nodes, accumulating text and inline annotations. Zero-length inlines are skipped.
-- Tag mapping: `Bold ↔ <strong>`, `Italic ↔ <em>`, `Underline ↔ <u>`.
-
-### 3. Editor — `src/lib/block-editor/editor/`
-
-`TextEditor` is a self-contained UI component. It imports its CSS, builds a toolbar + `contenteditable` div, and wires everything together.
-
-- `#render()` serializes the current `Text` state to DOM and restores selection.
-- `#handleInput()` parses the edited DOM back to `Text` and calls change listeners.
-- `#applyOrRemoveInline()` toggles formatting on the current selection using `isToggled`.
-- Selection is mapped between DOM positions and character offsets via `getCharOffset` / `findNodeAtOffset`.
-- IME composition events are handled separately to avoid premature parses.
-
-### 4. Public API — `src/lib/block-editor/index.ts`
-
-All classes and types intended for consumers must be exported from `index.ts`. When adding a new public class or type, add it here.
-
-## Blocks API
-
-### Tree navigation
-`Blocks` exposes three instance methods for positional queries:
-- `parent(id)` — parent block ID, or `null` for root blocks
-- `prevSibling(id)` — previous sibling ID, or `null` if first child
-- `nextSibling(id)` — next sibling ID, or `null` if last child
-
-All three throw if the `id` is not found.
-
-### Structural diffing
-`Blocks.diff(oldBlocks, newBlocks): BlocksChange[]` returns the structural differences between two states:
-- `{ type: 'removed', id }` — block present in old, absent in new
-- `{ type: 'moved', id, previousBlockId, parentBlockId }` — block whose parent or prevSibling changed
-
-Newly added blocks (not in old state) are ignored. Use this to compute `blockRemoved` and `blockMoved` events.
-
-### Domain-logic boundary rule
-**Tree-traversal and change-detection belong in `Blocks`, not in `BlockEditor` or any component.** If you need to know a block's parent, siblings, or what changed between two states, use the `Blocks` methods above — never re-implement traversal in the editor.
+**Tree-traversal and change-detection belong in `Blocks`, not in `BlockEditor` or any component.** If you need to know a block's parent, siblings, or what changed between two states, use the `Blocks` methods — never re-implement traversal in the editor.
 
 ## Event Infrastructure
 

--- a/.claude/rules/demo.md
+++ b/.claude/rules/demo.md
@@ -5,7 +5,7 @@
 - `src/routes/+page.svelte` — main demo page
 - `src/routes/+layout.svelte` — root layout; imports `layout.css`
 - `src/routes/layout.css` — global CSS and CSS custom properties (uses Tailwind via `@import 'tailwindcss'`)
-- `src/components/` — shared Svelte components (e.g. `resizable-layout.svelte`, `collapsible-section.svelte`, `json-panel.svelte`)
+- `src/components/` — shared Svelte components
 
 ## Boundary Rule
 
@@ -41,21 +41,7 @@ Always import from the `$lib/block-editor` alias — never use relative paths in
 
 ## Mounting the Editor
 
-Use `{@attach}` to hand a DOM node to the vanilla JS editor — the idiomatic Svelte 5 pattern for integrating class-based libraries:
-
-```svelte
-<script lang="ts">
-  import { BlockEditorWithToolbar } from '$lib/block-editor'
-
-  function mountEditor(node: HTMLElement) {
-    const editor = new BlockEditorWithToolbar(node, initialBlocks)
-    editor.onChange((b) => { /* ... */ })
-    return () => editor.destroy()
-  }
-</script>
-
-<div {@attach mountEditor}></div>
-```
+Use `{@attach}` to hand a DOM node to the vanilla JS editor — the idiomatic Svelte 5 pattern for integrating class-based libraries.
 
 ## Svelte MCP Server
 

--- a/.claude/rules/git-conventions.md
+++ b/.claude/rules/git-conventions.md
@@ -14,28 +14,6 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/) with the sev
 [optional footer(s)]
 ```
 
-### Subject Line Rules
-
-1. **Imperative mood** — "Fix bug", not "Fixed bug" or "Fixing bug". Test: *"If applied, this commit will ___"*
-2. **Capitalize** the first word
-3. **No trailing period**
-4. **≤50 characters** (hard cap 72 — GitHub truncates beyond that)
-5. **Separate from body** with a blank line
-6. **Do not describe how** — the diff shows that; the message explains why
-7. **One concern per commit** — if you need "and", split the commit
-
-### Types
-
-| Type | Meaning |
-|---|---|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `docs` | Documentation only |
-| `refactor` | Code change that neither fixes a bug nor adds a feature |
-| `test` | Adding or correcting tests |
-| `chore` | Maintenance (build, deps, config) |
-| `perf` | Performance improvement |
-
 Append `!` for breaking changes: `feat!: remove deprecated endpoint`
 
 ### Body

--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -56,7 +56,6 @@ Rules:
 - Omit `@param` and `@returns` when the prose adds nothing beyond the TypeScript type.
 - `@example` blocks must be valid, runnable code — treat them as executable specifications.
 - Do **not** include `@param {Type}` — TypeScript already has the type; repeating it is noise.
-- Do **not** add `@author` or `@version` — version control is the record of authorship.
 
 ## `@example` Discipline
 

--- a/.claude/rules/toolbar-button-ux.md
+++ b/.claude/rules/toolbar-button-ux.md
@@ -15,7 +15,6 @@ Guidelines drawn from WCAG 2.2, WAI-ARIA APG, Material Design 3, Apple HIG, and 
 - Set `cursor: default` (not `cursor: not-allowed`) on disabled buttons. `not-allowed` implies the user is doing something forbidden; `default` simply signals the action is unavailable right now.
 - **Do not remove disabled buttons from the DOM** — their presence communicates that the feature exists. Hide them only if the feature is permanently unavailable in this context.
 - Disabled buttons should still show a tooltip explaining *why* they are disabled when feasible (e.g., "Nothing to undo"). For simple toolbar buttons where the reason is obvious, the tooltip can be omitted.
-- Disabled buttons must not be reachable via `Tab` — the browser enforces this automatically when `disabled` is set on a `<button>`.
 
 ## Active / Toggled State
 


### PR DESCRIPTION
## Summary
Removes ~200 lines from the Claude rule files that restate widely-known conventions or browser-enforced behaviour, leaving only guidance that is non-obvious or project-specific.

## Why
Rule files loaded into every Claude session carry a token cost and a signal-to-noise cost. Content that any competent developer (or LLM) already knows dilutes the rules that actually matter, increasing the chance that project-specific constraints get overlooked.

## Changes
- **git-conventions.md** — removed Conventional Commits type table and Chris Beams' 7 subject-line rules (standard knowledge)
- **demo.md** — removed specific component filenames from File Structure (discoverable, stale risk); removed `{@attach}` code example (prose alone is sufficient)
- **toolbar-button-ux.md** — removed "disabled buttons not reachable via Tab" bullet (browser-enforced, not a rule we need to state)
- **jsdoc.md** — removed `@author`/`@version` bullet (universal best practice)
- **blockEditor.md** — removed "no Web Components, no framework" (already covered by Boundary Rule); collapsed `protected` note; removed redundant Public API sentence
- **CLAUDE.md** — removed Commands section, Feature Worktrees section, and Pull Request Workflow section (no longer reflect current workflow)

## Testing
- [ ] No code changes — rules-only

## Breaking Changes
- [ ] No

## Checklist
- [x] Self-reviewed the diff
- [x] No secrets or debug code included