### PR TITLE
feat: add markdown input shortcuts for list blocks

### DIFF
--- a/src/lib/block-editor/editor/BlockEditor.test.ts
+++ b/src/lib/block-editor/editor/BlockEditor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { BlockEditor } from './BlockEditor'
 import { BlockEditorWithToolbar } from './BlockEditorWithToolbar'
-import { Blocks, TextBlock, OrderedListBlock, type Block } from '../blocks/blocks'
+import { Blocks, TextBlock, OrderedListBlock, UnorderedListBlock, type Block } from '../blocks/blocks'
 import { Text, type InlineTypes } from '../text/text'
 import { BLOCK_EDITOR_EVENT_NAMES } from './events'
 import type { BlockDataUpdatedEventDto } from './events'
@@ -1267,6 +1267,111 @@ describe('convertBlockType', () => {
     setCursor(container, 'a', 0)
     editor.convertBlockType('text')
     expect(editor.getValue().getBlock('a')).toBeInstanceOf(TextBlock)
+    cleanup(editor, container)
+  })
+})
+
+// ─── markdown input shortcuts ────────────────────────────────────────────────
+
+describe('markdown input shortcuts', () => {
+  /** Simulate typing a character by mutating the DOM text and firing input. */
+  function simulateType(container: HTMLElement, blockId: string, newFullText: string, cursorAt: number): void {
+    const editable = getEditable(container)
+    const blockEl = editable.querySelector(`[id="${blockId}"]`)!
+    const p = blockEl.querySelector('p')!
+    p.textContent = newFullText
+    setCursor(container, blockId, cursorAt)
+    editable.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  it('typing "- " converts text block to unordered-list and strips marker', () => {
+    const container = makeContainer()
+    const editor = new BlockEditor(container, Blocks.from([dto('a', '')]))
+    getEditable(container).focus()
+    simulateType(container, 'a', '-', 1)
+    simulateType(container, 'a', '- ', 2)
+    const block = editor.getValue().getBlock('a')
+    expect(block.blockType).toBe('unordered-list')
+    expect(block.getText().text).toBe('')
+    cleanup(editor, container)
+  })
+
+  it('typing "* " converts text block to unordered-list and strips marker', () => {
+    const container = makeContainer()
+    const editor = new BlockEditor(container, Blocks.from([dto('a', '')]))
+    getEditable(container).focus()
+    simulateType(container, 'a', '*', 1)
+    simulateType(container, 'a', '* ', 2)
+    const block = editor.getValue().getBlock('a')
+    expect(block.blockType).toBe('unordered-list')
+    expect(block.getText().text).toBe('')
+    cleanup(editor, container)
+  })
+
+  it('typing "1. " converts text block to ordered-list and strips marker', () => {
+    const container = makeContainer()
+    const editor = new BlockEditor(container, Blocks.from([dto('a', '')]))
+    getEditable(container).focus()
+    simulateType(container, 'a', '1', 1)
+    simulateType(container, 'a', '1.', 2)
+    simulateType(container, 'a', '1. ', 3)
+    const block = editor.getValue().getBlock('a')
+    expect(block.blockType).toBe('ordered-list')
+    expect(block.getText().text).toBe('')
+    cleanup(editor, container)
+  })
+
+  it('preserves content after the marker', () => {
+    const container = makeContainer()
+    const editor = new BlockEditor(container, Blocks.from([dto('a', 'Hello')]))
+    getEditable(container).focus()
+    // Cursor at offset 1 (after imagined '-' inserted at position 0); full text is "- Hello"
+    simulateType(container, 'a', '- Hello', 2)
+    const block = editor.getValue().getBlock('a')
+    expect(block.blockType).toBe('unordered-list')
+    expect(block.getText().text).toBe('Hello')
+    cleanup(editor, container)
+  })
+
+  it('does not convert when block is already the target type', () => {
+    const container = makeContainer()
+    const initial = Blocks.from([new UnorderedListBlock('a', new Text('', []), [])])
+    const editor = new BlockEditor(container, initial)
+    getEditable(container).focus()
+    simulateType(container, 'a', '-', 1)
+    simulateType(container, 'a', '- ', 2)
+    expect(editor.getValue().getBlock('a').blockType).toBe('unordered-list')
+    // Text should NOT be stripped — no conversion occurred
+    expect(editor.getValue().getBlock('a').getText().text).toBe('- ')
+    cleanup(editor, container)
+  })
+
+  it('converts ordered-list to unordered-list via "- " trigger', () => {
+    const container = makeContainer()
+    const initial = Blocks.from([new OrderedListBlock('a', new Text('', []), [])])
+    const editor = new BlockEditor(container, initial)
+    getEditable(container).focus()
+    simulateType(container, 'a', '-', 1)
+    simulateType(container, 'a', '- ', 2)
+    const block = editor.getValue().getBlock('a')
+    expect(block.blockType).toBe('unordered-list')
+    expect(block.getText().text).toBe('')
+    cleanup(editor, container)
+  })
+
+  it('undo after "- " conversion restores text block with marker and space', () => {
+    const container = makeContainer()
+    const editor = new BlockEditor(container, Blocks.from([dto('a', '')]))
+    getEditable(container).focus()
+    simulateType(container, 'a', '-', 1)
+    simulateType(container, 'a', '- ', 2)
+    expect(editor.getValue().getBlock('a').blockType).toBe('unordered-list')
+
+    editor.undo()
+
+    const block = editor.getValue().getBlock('a')
+    expect(block.blockType).toBe('text')
+    expect(block.getText().text).toBe('- ')
     cleanup(editor, container)
   })
 })

--- a/src/lib/block-editor/editor/BlockEditor.ts
+++ b/src/lib/block-editor/editor/BlockEditor.ts
@@ -5,6 +5,7 @@ import { blocksSerializer } from '../blocks/serializer'
 import type { BlockEditorEventDtoMap, BlockEditorOptions, BlockSelection } from './events'
 import { BlockEventEmitter } from './BlockEventEmitter'
 import { BlockHistory } from './BlockHistory'
+import { InputRules } from './InputRules'
 import './block-editor.css'
 
 export { BlockOffset, BlockRange } from '../blocks/blocks'
@@ -572,9 +573,36 @@ export class BlockEditor {
 
     const pEl = getBlockElementContent(blockEl)
     const newText = textSerializer.parse(Array.from(pEl.childNodes))
+    const oldState = this.#state
     this.#state = this.#state.update(blockId, newText)
-    const blockType = this.#state.getBlock(blockId).blockType
-    this.#history.updateOrAdd(blockId, new BlockDataChanged(blockId, newText, blockType), this.#pendingSelectionBefore, sel)
+    const currentType = this.#state.getBlock(blockId).blockType
+
+    const match = InputRules.match(newText.text, sel.offset, currentType)
+    if (match) {
+      // Coalesce the space into the previous typing entry so that one undo
+      // restores a text block containing the full marker + space.
+      this.#history.updateOrAdd(
+        blockId,
+        new BlockDataChanged(blockId, newText, 'text'),
+        this.#pendingSelectionBefore,
+        sel,
+      )
+
+      // Strip the marker and convert block type.
+      const strippedText = newText.remove(0, match.stripLength)
+      this.#state = this.#state.update(blockId, strippedText)
+      this.#state = this.#state.convertType(blockId, blockId, match.targetType)
+
+      const cursorAfter = new BlockOffset(blockId, 0)
+      const changes = Blocks.diff(oldState, this.#state)
+      this.#history.add(changes, sel, cursorAfter)
+      this.#pendingSelectionBefore = null
+      this.#render(cursorAfter)
+      this.#emitter.scheduleDataUpdated(blockId)
+      return
+    }
+
+    this.#history.updateOrAdd(blockId, new BlockDataChanged(blockId, newText, currentType), this.#pendingSelectionBefore, sel)
     this.#pendingSelectionBefore = null
     this.#render(sel)
     this.#emitter.scheduleDataUpdated(blockId)

--- a/src/lib/block-editor/editor/InputRules.test.ts
+++ b/src/lib/block-editor/editor/InputRules.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { InputRules } from './InputRules'
+
+describe('InputRules.match', () => {
+  it('returns unordered-list match for "- " at cursor offset 2 on text block', () => {
+    expect(InputRules.match('- ', 2, 'text')).toEqual({ targetType: 'unordered-list', stripLength: 2 })
+  })
+
+  it('returns unordered-list match for "* " at cursor offset 2 on text block', () => {
+    expect(InputRules.match('* ', 2, 'text')).toEqual({ targetType: 'unordered-list', stripLength: 2 })
+  })
+
+  it('returns ordered-list match for "1. " at cursor offset 3 on text block', () => {
+    expect(InputRules.match('1. ', 3, 'text')).toEqual({ targetType: 'ordered-list', stripLength: 3 })
+  })
+
+  it('returns null for "- " when block is already unordered-list', () => {
+    expect(InputRules.match('- ', 2, 'unordered-list')).toBeNull()
+  })
+
+  it('returns null for "1. " when block is already ordered-list', () => {
+    expect(InputRules.match('1. ', 3, 'ordered-list')).toBeNull()
+  })
+
+  it('allows cross-type: "- " on ordered-list → unordered-list', () => {
+    expect(InputRules.match('- ', 2, 'ordered-list')).toEqual({ targetType: 'unordered-list', stripLength: 2 })
+  })
+
+  it('allows cross-type: "1. " on unordered-list → ordered-list', () => {
+    expect(InputRules.match('1. ', 3, 'unordered-list')).toEqual({ targetType: 'ordered-list', stripLength: 3 })
+  })
+
+  it('ignores "- " when cursor is at offset 1 (space not yet inserted)', () => {
+    expect(InputRules.match('- ', 1, 'text')).toBeNull()
+  })
+
+  it('ignores "2. " — only "1." triggers ordered list', () => {
+    expect(InputRules.match('2. ', 3, 'text')).toBeNull()
+  })
+
+  it('matches "- Hello" at cursor offset 2 — content after marker is irrelevant', () => {
+    expect(InputRules.match('- Hello', 2, 'text')).toEqual({ targetType: 'unordered-list', stripLength: 2 })
+  })
+})

--- a/src/lib/block-editor/editor/InputRules.ts
+++ b/src/lib/block-editor/editor/InputRules.ts
@@ -1,0 +1,40 @@
+import type { BlockTypes } from '../blocks/blocks'
+
+export interface InputRuleMatch {
+  targetType: Extract<BlockTypes, 'ordered-list' | 'unordered-list'>
+  stripLength: number
+}
+
+/**
+ * Pure pattern-matching logic for markdown-style input shortcuts.
+ * Has no DOM dependency and no side effects — all detection lives here.
+ *
+ * Supported triggers (all fire when Space is pressed):
+ * - `- ` or `* ` at cursor offset 2 → unordered-list
+ * - `1. ` at cursor offset 3 → ordered-list
+ *
+ * @remarks
+ * `cursorOffset` is the offset AFTER the space has been inserted (i.e.
+ * as seen in the `input` event). For `- `, the space lands at index 1 so
+ * the cursor arrives at offset 2.
+ *
+ * Cross-type conversions (ordered → unordered and vice-versa) are allowed.
+ * Same-type conversions are silently ignored (returns `null`).
+ */
+export class InputRules {
+  static match(
+    text: string,
+    cursorOffset: number,
+    currentType: BlockTypes,
+  ): InputRuleMatch | null {
+    if (cursorOffset === 2 && (text.startsWith('- ') || text.startsWith('* '))) {
+      if (currentType === 'unordered-list') return null
+      return { targetType: 'unordered-list', stripLength: 2 }
+    }
+    if (cursorOffset === 3 && text.startsWith('1. ')) {
+      if (currentType === 'ordered-list') return null
+      return { targetType: 'ordered-list', stripLength: 3 }
+    }
+    return null
+  }
+}


### PR DESCRIPTION
Typing `- `, `* `, or `1. ` at the start of a block (cursor immediately
after the marker characters) converts a text block to an unordered-list
or ordered-list block. The marker characters are stripped; any content
after the cursor is preserved.

One Ctrl+Z undoes the conversion and restores the original text block
containing the full marker and space. Cross-type conversions (e.g.
ordered → unordered) are allowed; same-type triggers are ignored.

New InputRules class encapsulates all pattern-matching logic as a pure
function with no DOM dependency, independently tested.