### PR TITLE
fix: normalize nbsp in markdown shortcut detection

### DIFF
--- a/packages/block-editor/src/editor/InputRules.test.ts
+++ b/packages/block-editor/src/editor/InputRules.test.ts
@@ -41,6 +41,13 @@ describe('InputRules.match', () => {
   it('matches "- Hello" at cursor offset 2 — content after marker is irrelevant', () => {
     expect(InputRules.match('- Hello', 2, 'text')).toEqual({ targetType: 'unordered-list', stripLength: 2 })
   })
+
+  it('matches when space is \\u00a0 (browsers insert nbsp at end of contenteditable text)', () => {
+    expect(InputRules.match('-\u00a0', 2, 'text')).toEqual({ targetType: 'unordered-list', stripLength: 2 })
+    expect(InputRules.match('*\u00a0', 2, 'text')).toEqual({ targetType: 'unordered-list', stripLength: 2 })
+    expect(InputRules.match('1.\u00a0', 3, 'text')).toEqual({ targetType: 'ordered-list', stripLength: 3 })
+    expect(InputRules.match('#\u00a0', 2, 'text')).toEqual({ targetType: 'header', headerLevel: 1, stripLength: 2 })
+  })
 })
 
 describe('InputRules.match — heading shortcuts', () => {

--- a/packages/block-editor/src/editor/InputRules.ts
+++ b/packages/block-editor/src/editor/InputRules.ts
@@ -41,21 +41,25 @@ export class InputRules {
     cursorOffset: number,
     currentType: BlockTypes,
   ): InputRuleMatch | null {
-    if (cursorOffset === 2 && (text.startsWith('- ') || text.startsWith('* '))) {
+    // Browsers insert \u00a0 (non-breaking space) instead of a regular space
+    // when the caret is at the end of a contenteditable block (common in empty
+    // blocks). Normalize so the patterns below match either space character.
+    const t = text.replace(/\u00a0/g, ' ')
+    if (cursorOffset === 2 && (t.startsWith('- ') || t.startsWith('* '))) {
       if (currentType === 'unordered-list') return null
       return { targetType: 'unordered-list', stripLength: 2 }
     }
-    if (cursorOffset === 3 && text.startsWith('1. ')) {
+    if (cursorOffset === 3 && t.startsWith('1. ')) {
       if (currentType === 'ordered-list') return null
       return { targetType: 'ordered-list', stripLength: 3 }
     }
-    if (cursorOffset === 2 && text.startsWith('# ')) {
+    if (cursorOffset === 2 && t.startsWith('# ')) {
       return { targetType: 'header', headerLevel: 1, stripLength: 2 }
     }
-    if (cursorOffset === 3 && text.startsWith('## ')) {
+    if (cursorOffset === 3 && t.startsWith('## ')) {
       return { targetType: 'header', headerLevel: 2, stripLength: 3 }
     }
-    if (cursorOffset === 4 && text.startsWith('### ')) {
+    if (cursorOffset === 4 && t.startsWith('### ')) {
       return { targetType: 'header', headerLevel: 3, stripLength: 4 }
     }
     return null


### PR DESCRIPTION
## Summary
Fix markdown shortcuts (`- `, `* `, `1. `, `# `, etc.) not triggering in empty text blocks.

## Why
Browsers insert `\u00a0` (non-breaking space) instead of a regular space when the caret is at the end of contenteditable text. In an empty block the marker space is always trailing, so `"- "` becomes `"-\u00a0"` and `InputRules.match` never fires. Blocks with existing content work because the space is followed by text, so browsers use a regular space.

## Changes
- Normalize `\u00a0` → regular space in `InputRules.match` before pattern matching

## Testing
- [x] Unit tests added: `cd packages/block-editor && npx vitest run src/editor/InputRules.test.ts`
- [x] Type-checked: `pnpm check`
- [x] Manual testing:
  1. Click into an empty text block, type `- ` → converts to unordered list
  2. Type `* ` in empty block → converts to unordered list
  3. Type `1. ` in empty block → converts to ordered list
  4. Type `# ` in empty block → converts to H1
  5. Undo/redo still works after typing

## Breaking Changes
- [x] No

## Checklist
- [x] Self-reviewed the diff
- [x] Tests pass locally
- [x] Type-checked (`pnpm check`)
- [x] No secrets or debug code included

🤖 Generated with [Claude Code](https://claude.com/claude-code)