### PR TITLE
feat: single-day DailyNoteEditor with persistence end-to-end

### DIFF
--- a/apps/demo/src/routes/daily-note/+page.svelte
+++ b/apps/demo/src/routes/daily-note/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+    import { DailyNoteEditor } from '@memoir/block-editor'
+    import type { NoteProvider, AnyBlock } from '@memoir/block-editor'
+    import ThemeToggle from '../../components/theme-toggle.svelte'
+
+    // In-memory NoteProvider — stores one note per date in a Map.
+    class InMemoryNoteProvider implements NoteProvider {
+        #store = new Map<string, ReadonlyArray<AnyBlock>>()
+
+        async load(date: string): Promise<ReadonlyArray<AnyBlock> | null> {
+            return this.#store.get(date) ?? null
+        }
+
+        async save(date: string, blocks: ReadonlyArray<AnyBlock>): Promise<void> {
+            this.#store.set(date, blocks)
+        }
+    }
+
+    const provider = new InMemoryNoteProvider()
+    const today = new Date().toISOString().slice(0, 10)
+
+    function mountEditor(provider: NoteProvider, date: string) {
+        return (node: HTMLElement) => {
+            const editor = new DailyNoteEditor(node, provider, date)
+            return () => editor.destroy()
+        }
+    }
+</script>
+
+<div class="relative min-h-dvh">
+    <div class="absolute top-4 right-4 z-10">
+        <ThemeToggle />
+    </div>
+    <div class="max-w-2xl mx-auto px-6 pt-12 pb-8">
+        <div {@attach mountEditor(provider, today)}></div>
+    </div>
+</div>

--- a/apps/tauri-app/src-tauri/src/db.rs
+++ b/apps/tauri-app/src-tauri/src/db.rs
@@ -53,6 +53,19 @@ pub fn load_note(conn: &Connection, id: &str) -> rusqlite::Result<Option<NoteDto
     }
 }
 
+/// Return the note for `date` (ISO YYYY-MM-DD), creating an empty one if absent.
+///
+/// The note `id` is the ISO date string. Content is initialised to `"[]"` (an
+/// empty block array) so callers always receive a valid, parseable note.
+/// Idempotent — calling twice for the same date returns the same row.
+pub fn get_or_create_daily_note(conn: &Connection, date: &str) -> rusqlite::Result<NoteDto> {
+    if let Some(note) = load_note(conn, date)? {
+        return Ok(note);
+    }
+    save_note(conn, date, "[]")?;
+    load_note(conn, date).map(|opt| opt.expect("note must exist after save"))
+}
+
 /// List all notes, returning metadata only (no content)
 pub fn list_notes(conn: &Connection) -> rusqlite::Result<Vec<NoteMetadataDto>> {
     let mut stmt = conn.prepare("SELECT id, updated_at FROM notes ORDER BY updated_at DESC")?;
@@ -155,5 +168,36 @@ mod tests {
         let conn = test_conn();
         let result = load_note(&conn, "does-not-exist").unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn get_or_create_creates_note_when_absent() {
+        let conn = test_conn();
+        let note = get_or_create_daily_note(&conn, "2024-01-15").unwrap();
+        assert_eq!(note.id, "2024-01-15");
+        assert_eq!(note.content, "[]");
+        assert!(!note.updated_at.is_empty());
+    }
+
+    #[test]
+    fn get_or_create_returns_existing_note() {
+        let conn = test_conn();
+        save_note(&conn, "2024-01-15", r#"[{"blockType":"text"}]"#).unwrap();
+        let note = get_or_create_daily_note(&conn, "2024-01-15").unwrap();
+        assert_eq!(note.content, r#"[{"blockType":"text"}]"#);
+    }
+
+    #[test]
+    fn get_or_create_is_idempotent() {
+        let conn = test_conn();
+        let first = get_or_create_daily_note(&conn, "2024-01-15").unwrap();
+        let second = get_or_create_daily_note(&conn, "2024-01-15").unwrap();
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.content, second.content);
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM notes", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
     }
 }

--- a/apps/tauri-app/src-tauri/src/lib.rs
+++ b/apps/tauri-app/src-tauri/src/lib.rs
@@ -24,6 +24,12 @@ fn list_notes(state: tauri::State<DbState>) -> Result<Vec<db::NoteMetadataDto>, 
     db::list_notes(&conn).map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+fn get_or_create_daily_note(state: tauri::State<DbState>, date: String) -> Result<db::NoteDto, String> {
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+    db::get_or_create_daily_note(&conn, &date).map_err(|e| e.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -48,7 +54,7 @@ pub fn run() {
             app.manage(DbState(Mutex::new(conn)));
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![save_note, load_note, list_notes])
+        .invoke_handler(tauri::generate_handler![save_note, load_note, list_notes, get_or_create_daily_note])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/apps/tauri-app/src/lib/daily-note.svelte
+++ b/apps/tauri-app/src/lib/daily-note.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { DailyNoteEditor } from '@memoir/block-editor'
+	import type { NoteProvider } from '@memoir/block-editor'
+
+	let { provider, date }: { provider: NoteProvider; date: string } = $props()
+
+	function mountEditor(provider: NoteProvider, date: string) {
+		return (node: HTMLElement) => {
+			const editor = new DailyNoteEditor(node, provider, date)
+			return () => editor.destroy()
+		}
+	}
+</script>
+
+<div {@attach mountEditor(provider, date)}></div>

--- a/apps/tauri-app/src/lib/tauri-note-provider.ts
+++ b/apps/tauri-app/src/lib/tauri-note-provider.ts
@@ -1,0 +1,28 @@
+import { invoke } from '@tauri-apps/api/core'
+import type { NoteProvider } from '@memoir/block-editor'
+import type { AnyBlock } from '@memoir/block-editor'
+
+/**
+ * `NoteProvider` backed by Tauri IPC commands.
+ *
+ * @remarks
+ * `load` calls `get_or_create_daily_note` so a row is always returned — the
+ * note is created with empty content on first access. This matches the
+ * requirement that daily notes are non-deletable and always exist for any
+ * date that has been opened.
+ */
+export class TauriNoteProvider implements NoteProvider {
+  async load(date: string): Promise<ReadonlyArray<AnyBlock> | null> {
+    const note = await invoke<{ id: string; content: string; updated_at: string }>(
+      'get_or_create_daily_note',
+      { date },
+    )
+    const parsed: unknown = JSON.parse(note.content)
+    if (!Array.isArray(parsed) || parsed.length === 0) return null
+    return parsed as AnyBlock[]
+  }
+
+  async save(date: string, blocks: ReadonlyArray<AnyBlock>): Promise<void> {
+    await invoke('save_note', { id: date, content: JSON.stringify(blocks) })
+  }
+}

--- a/apps/tauri-app/src/routes/desktop/+page.svelte
+++ b/apps/tauri-app/src/routes/desktop/+page.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
-	import PersistedEditor from '$lib/persisted-editor.svelte'
+	import DailyNote from '$lib/daily-note.svelte'
+	import { TauriNoteProvider } from '$lib/tauri-note-provider'
+
+	const provider = new TauriNoteProvider()
+	const today = new Date().toISOString().slice(0, 10)
 </script>
 
 <div class="min-h-dvh">
 	<div class="mx-auto max-w-3xl px-8 pt-12 pb-8">
-		<PersistedEditor id="default" />
+		<DailyNote {provider} date={today} />
 	</div>
 </div>

--- a/apps/tauri-app/src/routes/mobile/+page.svelte
+++ b/apps/tauri-app/src/routes/mobile/+page.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
-	import PersistedEditor from '$lib/persisted-editor.svelte'
+	import DailyNote from '$lib/daily-note.svelte'
+	import { TauriNoteProvider } from '$lib/tauri-note-provider'
+
+	const provider = new TauriNoteProvider()
+	const today = new Date().toISOString().slice(0, 10)
 </script>
 
 <div class="min-h-dvh">
 	<div class="w-full px-4 pt-6 pb-4">
-		<PersistedEditor id="default" />
+		<DailyNote {provider} date={today} />
 	</div>
 </div>

--- a/packages/block-editor/src/editor/DailyNoteEditor.test.ts
+++ b/packages/block-editor/src/editor/DailyNoteEditor.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { DailyNoteEditor } from './DailyNoteEditor'
+import { TextBlock } from '../blocks/blocks'
+import { Text } from '../text/text'
+import type { NoteProvider } from './NoteProvider'
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeContainer(): HTMLElement {
+  const div = document.createElement('div')
+  document.body.appendChild(div)
+  return div
+}
+
+function makeProvider(
+  blocks: TextBlock[] | null = null,
+): NoteProvider & { saveCalls: Array<{ date: string }> } {
+  const saveCalls: Array<{ date: string }> = []
+  return {
+    saveCalls,
+    load: vi.fn().mockResolvedValue(blocks),
+    save: vi.fn().mockImplementation((date: string) => {
+      saveCalls.push({ date })
+      return Promise.resolve()
+    }),
+  }
+}
+
+function getEditable(container: HTMLElement): HTMLElement {
+  return container.querySelector('.block-editor-editable') as HTMLElement
+}
+
+function keydown(container: HTMLElement, key: string): void {
+  const editable = getEditable(container)
+  editable.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }))
+}
+
+function setCursor(container: HTMLElement, blockId: string, offset: number): void {
+  const editable = getEditable(container)
+  const blockEl = editable.querySelector(`[id="${blockId}"]`)!
+  const p = blockEl.querySelector('p, h1, h2, h3')!
+
+  const range = document.createRange()
+  const walker = document.createTreeWalker(p, NodeFilter.SHOW_TEXT)
+  let node: Node | null = walker.nextNode()
+
+  if (node) {
+    range.setStart(node, offset)
+    range.setEnd(node, offset)
+  } else {
+    range.setStart(p, 0)
+    range.setEnd(p, 0)
+  }
+
+  window.getSelection()!.removeAllRanges()
+  window.getSelection()!.addRange(range)
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('DailyNoteEditor', () => {
+  const containers: HTMLElement[] = []
+  const editors: DailyNoteEditor[] = []
+
+  afterEach(() => {
+    editors.forEach((e) => e.destroy())
+    containers.forEach((c) => c.remove())
+    editors.length = 0
+    containers.length = 0
+  })
+
+  function make(
+    provider: NoteProvider,
+    date = '2024-01-15',
+  ): { editor: DailyNoteEditor; container: HTMLElement } {
+    const container = makeContainer()
+    containers.push(container)
+    const editor = new DailyNoteEditor(container, provider, date)
+    editors.push(editor)
+    return { editor, container }
+  }
+
+  it('mounts elements into the container', () => {
+    const { container } = make(makeProvider())
+    expect(container.children.length).toBeGreaterThan(0)
+  })
+
+  it('renders a non-editable date header', () => {
+    const { container } = make(makeProvider(), '2024-01-15')
+    const header = container.querySelector('.daily-note-header')
+    expect(header).toBeTruthy()
+    expect(header!.getAttribute('contenteditable')).not.toBe('true')
+    expect((header as HTMLElement).textContent!.length).toBeGreaterThan(0)
+  })
+
+  it('renders an editable content area', () => {
+    const { container } = make(makeProvider())
+    const editable = getEditable(container)
+    expect(editable).toBeTruthy()
+    expect(editable.contentEditable).toBe('true')
+  })
+
+  it('starts with one empty block when provider returns null', async () => {
+    const { container } = make(makeProvider(null))
+    await vi.waitFor(() => {
+      expect(container.querySelectorAll('.block').length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  it('loads and renders blocks from provider', async () => {
+    const blocks = [new TextBlock('b1', new Text('hello world', []), [])]
+    const { container } = make(makeProvider(blocks))
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('[id="b1"]')).toBeTruthy()
+    })
+    expect(getEditable(container).textContent).toContain('hello world')
+  })
+
+  it('calls provider.load with the given date', async () => {
+    const provider = makeProvider()
+    make(provider, '2024-03-20')
+    await vi.waitFor(() => {
+      expect(provider.load).toHaveBeenCalledWith('2024-03-20')
+    })
+  })
+
+  it('saves via provider on structural change', async () => {
+    const blocks = [new TextBlock('b1', new Text('hello', []), [])]
+    const provider = makeProvider(blocks)
+    const { container } = make(provider, '2024-01-15')
+
+    // Wait for initial load
+    await vi.waitFor(() => {
+      expect(container.querySelector('[id="b1"]')).toBeTruthy()
+    })
+
+    // Place cursor at end of b1 and press Enter
+    setCursor(container, 'b1', 5)
+    keydown(container, 'Enter')
+
+    expect(provider.saveCalls.length).toBeGreaterThan(0)
+    expect(provider.saveCalls[0].date).toBe('2024-01-15')
+  })
+
+  it('does not call setValue after destroy', async () => {
+    const blocks = [new TextBlock('b1', new Text('loaded', []), [])]
+    let resolveLoad!: (v: TextBlock[] | null) => void
+    const provider: NoteProvider = {
+      load: () => new Promise((res) => { resolveLoad = res }),
+      save: vi.fn().mockResolvedValue(undefined),
+    }
+
+    const container = makeContainer()
+    containers.push(container)
+    const editor = new DailyNoteEditor(container, provider, '2024-01-15')
+    // Destroy before load completes
+    editor.destroy()
+    // Now resolve — should not throw or update DOM
+    resolveLoad(blocks)
+    // Small tick to let the promise chain run
+    await Promise.resolve()
+    // Block b1 should NOT be in the (already-destroyed) editor
+    expect(container.querySelector('[id="b1"]')).toBeFalsy()
+  })
+})

--- a/packages/block-editor/src/editor/DailyNoteEditor.ts
+++ b/packages/block-editor/src/editor/DailyNoteEditor.ts
@@ -1,0 +1,82 @@
+import { Blocks } from '../blocks/blocks'
+import type { BlockEditorOptions } from './events'
+import { BlockEditor } from './BlockEditor'
+import type { NoteProvider } from './NoteProvider'
+import './daily-note-editor.css'
+
+const DATA_EVENTS = ['blockCreated', 'blockDataUpdated', 'blockRemoved', 'blockMoved'] as const
+
+/**
+ * Single-day note editor with a read-only date header and auto-save.
+ *
+ * @remarks
+ * Composes `BlockEditor` for the editable area and adds a non-interactive
+ * date header. Block content is loaded asynchronously from `provider.load`
+ * on construction and persisted on every data change via `provider.save`.
+ *
+ * @example
+ * const editor = new DailyNoteEditor(container, provider, '2024-01-15')
+ * // later:
+ * editor.destroy()
+ */
+export class DailyNoteEditor {
+  #editor: BlockEditor
+  #provider: NoteProvider
+  #date: string
+  #destroyed = false
+
+  constructor(container: HTMLElement, provider: NoteProvider, date: string, opts?: BlockEditorOptions) {
+    this.#provider = provider
+    this.#date = date
+
+    const header = document.createElement('div')
+    header.className = 'daily-note-header'
+    header.textContent = DailyNoteEditor.#formatDate(date)
+    container.appendChild(header)
+
+    const editorContainer = document.createElement('div')
+    editorContainer.className = 'daily-note-content'
+    container.appendChild(editorContainer)
+
+    this.#editor = new BlockEditor(editorContainer, undefined, opts)
+
+    provider.load(date).then((blocks) => {
+      if (this.#destroyed) return
+      if (blocks !== null) {
+        this.#editor.setValue(Blocks.from(blocks))
+      }
+    })
+
+    for (const event of DATA_EVENTS) {
+      this.#editor.addEventListener(event, () => this.#save())
+    }
+  }
+
+  /**
+   * Remove the editor from the DOM and cancel any pending debounced events.
+   *
+   * @remarks
+   * Safe to call at any time — if an async `load` is still in flight it will
+   * be ignored once it resolves.
+   */
+  destroy(): void {
+    this.#destroyed = true
+    this.#editor.destroy()
+  }
+
+  // ─── Private ─────────────────────────────────────────────────────────────────
+
+  static #formatDate(isoDate: string): string {
+    const [year, month, day] = isoDate.split('-').map(Number)
+    return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  }
+
+  #save(): void {
+    this.#provider.save(this.#date, this.#editor.getValue().blocks)
+  }
+}

--- a/packages/block-editor/src/editor/NoteProvider.ts
+++ b/packages/block-editor/src/editor/NoteProvider.ts
@@ -1,0 +1,27 @@
+import type { AnyBlock } from '../blocks/blocks'
+
+/**
+ * Persistence contract for a note keyed by ISO date (YYYY-MM-DD).
+ *
+ * @remarks
+ * `load` returns `null` when no note exists for the given date, allowing
+ * callers to distinguish "no note yet" from "empty note". `save` is called
+ * after every content change; implementations should debounce at the
+ * transport layer if needed.
+ */
+export interface NoteProvider {
+  /**
+   * Load block data for `date`, or `null` if no note exists yet.
+   *
+   * @param date - ISO date string, e.g. `"2024-01-15"`.
+   */
+  load(date: string): Promise<ReadonlyArray<AnyBlock> | null>
+
+  /**
+   * Persist block data for `date`.
+   *
+   * @param date - ISO date string, e.g. `"2024-01-15"`.
+   * @param blocks - Current block tree to persist.
+   */
+  save(date: string, blocks: ReadonlyArray<AnyBlock>): Promise<void>
+}

--- a/packages/block-editor/src/editor/daily-note-editor.css
+++ b/packages/block-editor/src/editor/daily-note-editor.css
@@ -1,0 +1,15 @@
+.daily-note-editor {
+  display: flex;
+  flex-direction: column;
+}
+
+.daily-note-header {
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.5;
+  padding-bottom: 0.5rem;
+  user-select: none;
+  pointer-events: none;
+}

--- a/packages/block-editor/src/index.ts
+++ b/packages/block-editor/src/index.ts
@@ -2,6 +2,8 @@ export { Block, TextBlock, OrderedListBlock, UnorderedListBlock, HeaderBlock, He
 export { BlockEditor } from "./editor/BlockEditor";
 export { BlockRenderer } from "./editor/BlockRenderer";
 export { InputHandler } from "./editor/InputHandler";
+export { DailyNoteEditor } from "./editor/DailyNoteEditor";
+export type { NoteProvider } from "./editor/NoteProvider";
 export { BLOCK_EDITOR_EVENT_NAMES } from "./editor/events"
 export type {
   BlockEditorOptions,


### PR DESCRIPTION
## Summary

Delivers a thin vertical slice from issue #63: a single day's note from database to screen, editable and auto-saved via a `NoteProvider` abstraction.

## Why

Users need a daily note that opens automatically to today, persists across sessions, and is created on first access without any setup. This PR introduces a clean `NoteProvider` interface so `DailyNoteEditor` works in any context (Tauri app, demo, future web) by swapping the provider.

## Changes

- **`NoteProvider` interface** (`packages/block-editor`) — `load(date) / save(date, blocks)` exported from `index.ts`
- **`DailyNoteEditor` class** (`packages/block-editor`) — read-only date header + `BlockEditor`; async-loads from provider on mount; auto-saves on every data event; 8 unit tests
- **`get_or_create_daily_note`** (Rust) — returns existing row or inserts `"[]"` if absent; idempotent; 3 new unit tests (9 total)
- **`TauriNoteProvider`** — calls `get_or_create_daily_note` on load, `save_note` on save
- **`DailyNote.svelte`** — thin `{@attach}` wrapper over `DailyNoteEditor`
- **Desktop / mobile routes** — replaced `PersistedEditor id="default"` with `DailyNote` using today's ISO date
- **Demo `/daily-note` page** — `DailyNoteEditor` with `InMemoryNoteProvider`

## Testing

- [ ] Unit tests: `pnpm --filter @memoir/block-editor vitest run` — 598 passing (8 new)
- [ ] Rust tests: `cargo test` in `src-tauri/` — 9 passing (3 new)
- [ ] Type-check: `pnpm check` — 0 errors, 0 warnings
- [ ] Manual: run `pnpm dev`, navigate to `/daily-note`

## Breaking Changes

- [x] No

## Related Issues

Closes #63

## Reviewer Notes

Start with `packages/block-editor/src/editor/NoteProvider.ts` and `DailyNoteEditor.ts` for the library design, then `apps/tauri-app/src/lib/tauri-note-provider.ts` for the Tauri binding, then the route files.

`DailyNoteEditor` has no public API beyond `destroy()` — all interaction is through the DOM and provider callbacks.