### PR TITLE
feat: extract BlockRenderer/InputHandler and add DailyNoteHistory cross-day undo/redo

### DIFF
--- a/packages/block-editor/src/editor/BlockEditor.ts
+++ b/packages/block-editor/src/editor/BlockEditor.ts
@@ -30,6 +30,8 @@ export class BlockEditor {
   #emitter: BlockEventEmitter
   #renderer: BlockRenderer
   #input: InputHandler
+  #onTopBoundaryEscape: ((x: number) => void) | undefined
+  #onBottomBoundaryEscape: ((x: number) => void) | undefined
 
   #onSelectionChange = (): void => {
     if (document.activeElement === this.#renderer.editable) {
@@ -43,6 +45,8 @@ export class BlockEditor {
   }
 
   constructor(container: HTMLElement, initial?: Blocks, opts: BlockEditorOptions = {}) {
+    this.#onTopBoundaryEscape    = opts.onTopBoundaryEscape    as ((x: number) => void) | undefined
+    this.#onBottomBoundaryEscape = opts.onBottomBoundaryEscape as ((x: number) => void) | undefined
     this.#state = initial ?? Blocks.from([Blocks.createTextBlock()])
     this.#history = new BlockHistory(this.#state)
     this.#emitter = new BlockEventEmitter(
@@ -289,6 +293,33 @@ export class BlockEditor {
     }
   }
 
+  /**
+   * Focus the editable and place the cursor at the start of the first block.
+   * If `x` is provided, use it as the client X coordinate to position the cursor
+   * on the first visual line at the same column (mirrors the ArrowDown position).
+   */
+  focusStart(x?: number): void {
+    const firstBlock = this.#state.blocks[0]
+    if (!firstBlock) return
+    this.#renderer.editable.focus()
+    if (x !== undefined && this.#placeCaretAtX(firstBlock.id, x, 'start')) return
+    this.#renderer.restoreSelection(new BlockOffset(firstBlock.id, 0))
+  }
+
+  /**
+   * Focus the editable and place the cursor at the end of the last block.
+   * If `x` is provided, use it as the client X coordinate to position the cursor
+   * on the last visual line at the same column (mirrors the ArrowUp position).
+   */
+  focusEnd(x?: number): void {
+    const blocks = this.#state.blocks
+    const lastBlock = blocks[blocks.length - 1]
+    if (!lastBlock) return
+    this.#renderer.editable.focus()
+    if (x !== undefined && this.#placeCaretAtX(lastBlock.id, x, 'end')) return
+    this.#renderer.restoreSelection(new BlockOffset(lastBlock.id, lastBlock.getLength()))
+  }
+
   canUndo(): boolean { return this.#history.canUndo() }
   canRedo(): boolean { return this.#history.canRedo() }
 
@@ -324,6 +355,79 @@ export class BlockEditor {
 
   // ─── Private helpers ────────────────────────────────────────────────────────
 
+  /**
+   * Returns the client X coordinate of the current cursor or focus end of a selection.
+   * Used to preserve horizontal position when crossing section boundaries.
+   */
+  #getCursorClientX(): number {
+    const domSel = window.getSelection()
+    if (!domSel) return 0
+    if (!domSel.isCollapsed && domSel.focusNode) {
+      try {
+        const focusRange = document.createRange()
+        focusRange.setStart(domSel.focusNode, domSel.focusOffset)
+        focusRange.collapse(true)
+        const rect = focusRange.getBoundingClientRect()
+        if (rect.height > 0) return rect.left
+      } catch { /* fall through */ }
+    }
+    if (domSel.rangeCount === 0) return 0
+    return domSel.getRangeAt(0).getBoundingClientRect().left
+  }
+
+  #isOnFirstVisualLine(blockId: BlockId): boolean {
+    const domSel = window.getSelection()
+    if (!domSel || domSel.rangeCount === 0) return false
+    const cursorRect = domSel.getRangeAt(0).getBoundingClientRect()
+    if (cursorRect.height === 0) return false
+    const blockEl = this.#renderer.editable.querySelector(`[id="${blockId}"]`)
+    const textEl = blockEl?.querySelector('p, h1, h2, h3')
+    if (!textEl) return false
+    const textRect = textEl.getBoundingClientRect()
+    return cursorRect.top - cursorRect.height < textRect.top
+  }
+
+  #isOnLastVisualLine(blockId: BlockId): boolean {
+    const domSel = window.getSelection()
+    if (!domSel || domSel.rangeCount === 0) return false
+    const cursorRect = domSel.getRangeAt(0).getBoundingClientRect()
+    if (cursorRect.height === 0) return false
+    const blockEl = this.#renderer.editable.querySelector(`[id="${blockId}"]`)
+    const textEl = blockEl?.querySelector('p, h1, h2, h3')
+    if (!textEl) return false
+    const textRect = textEl.getBoundingClientRect()
+    return cursorRect.bottom + cursorRect.height > textRect.bottom
+  }
+
+  #placeCaretAtX(blockId: BlockId, x: number, line: 'start' | 'end'): boolean {
+    const blockEl = this.#renderer.editable.querySelector(`[id="${blockId}"]`)
+    const textEl = blockEl?.querySelector('p, h1, h2, h3')
+    if (!textEl) return false
+    const rect = textEl.getBoundingClientRect()
+    if (rect.height === 0) return false
+    const y = line === 'start'
+      ? rect.top + rect.height * 0.5
+      : rect.bottom - rect.height * 0.5
+    const range = document.caretRangeFromPoint?.(x, y)
+      ?? this.#caretRangeFromPointFallback(x, y)
+    if (!range || !this.#renderer.editable.contains(range.startContainer)) return false
+    const domSel = window.getSelection()
+    if (!domSel) return false
+    domSel.removeAllRanges()
+    domSel.addRange(range)
+    return true
+  }
+
+  /** Firefox polyfill for `document.caretRangeFromPoint`. */
+  #caretRangeFromPointFallback(x: number, y: number): Range | null {
+    const pos = (document as { caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null }).caretPositionFromPoint?.(x, y)
+    if (!pos) return null
+    const range = document.createRange()
+    range.setStart(pos.offsetNode, pos.offset)
+    range.collapse(true)
+    return range
+  }
+
   #emitEvents(oldState: Blocks): void {
     const changes = Blocks.diff(oldState, this.#state)
     if (changes.length > 0) {
@@ -358,6 +462,41 @@ export class BlockEditor {
 
     const sel = this.#renderer.getSelection()
     this.#input.pendingSelectionBefore = sel
+
+    if (e.key === 'ArrowUp' && this.#onTopBoundaryEscape) {
+      const firstBlock = this.#state.blocks[0]
+      if (firstBlock) {
+        let shouldEscape = false
+        if (sel instanceof BlockOffset && sel.blockId === firstBlock.id) {
+          shouldEscape = sel.offset === 0 || this.#isOnFirstVisualLine(firstBlock.id)
+        } else if (sel instanceof BlockRange && sel.start.blockId === firstBlock.id && sel.start.offset === 0) {
+          shouldEscape = true
+        }
+        if (shouldEscape) {
+          e.preventDefault()
+          this.#onTopBoundaryEscape(this.#getCursorClientX())
+          return
+        }
+      }
+    }
+
+    if (e.key === 'ArrowDown' && this.#onBottomBoundaryEscape) {
+      const blocks = this.#state.blocks
+      const lastBlock = blocks[blocks.length - 1]
+      if (lastBlock) {
+        let shouldEscape = false
+        if (sel instanceof BlockOffset && sel.blockId === lastBlock.id) {
+          shouldEscape = sel.offset === lastBlock.getLength() || this.#isOnLastVisualLine(lastBlock.id)
+        } else if (sel instanceof BlockRange && sel.end.blockId === lastBlock.id && sel.end.offset === lastBlock.getLength()) {
+          shouldEscape = true
+        }
+        if (shouldEscape) {
+          e.preventDefault()
+          this.#onBottomBoundaryEscape(this.#getCursorClientX())
+          return
+        }
+      }
+    }
 
     if (e.key === 'Enter') {
       e.preventDefault()

--- a/packages/block-editor/src/editor/DailyNoteEditor.test.ts
+++ b/packages/block-editor/src/editor/DailyNoteEditor.test.ts
@@ -143,6 +143,34 @@ describe('DailyNoteEditor', () => {
     expect(provider.saveCalls[0].date).toBe('2024-01-15')
   })
 
+  it('focusStart places cursor at start of first block', async () => {
+    const blocks = [new TextBlock('b1', new Text('hello', []), [])]
+    const { container, editor } = make(makeProvider(blocks))
+    await vi.waitFor(() => expect(container.querySelector('[id="b1"]')).toBeTruthy())
+
+    editor.focusStart()
+
+    const sel = window.getSelection()!
+    expect(sel.rangeCount).toBeGreaterThan(0)
+    const range = sel.getRangeAt(0)
+    expect(range.collapsed).toBe(true)
+    expect(container.querySelector('[id="b1"]')!.contains(range.startContainer)).toBe(true)
+  })
+
+  it('focusEnd places cursor at end of last block', async () => {
+    const blocks = [new TextBlock('b1', new Text('hello', []), [])]
+    const { container, editor } = make(makeProvider(blocks))
+    await vi.waitFor(() => expect(container.querySelector('[id="b1"]')).toBeTruthy())
+
+    editor.focusEnd()
+
+    const sel = window.getSelection()!
+    expect(sel.rangeCount).toBeGreaterThan(0)
+    const range = sel.getRangeAt(0)
+    expect(range.collapsed).toBe(true)
+    expect(container.querySelector('[id="b1"]')!.contains(range.startContainer)).toBe(true)
+  })
+
   it('does not call setValue after destroy', async () => {
     const blocks = [new TextBlock('b1', new Text('loaded', []), [])]
     let resolveLoad!: (v: TextBlock[] | null) => void

--- a/packages/block-editor/src/editor/DailyNoteEditor.ts
+++ b/packages/block-editor/src/editor/DailyNoteEditor.ts
@@ -53,6 +53,22 @@ export class DailyNoteEditor {
   }
 
   /**
+   * Focus and place cursor at the start of the first block.
+   * Pass `x` (client X) to land at the same horizontal column on the first visual line.
+   */
+  focusStart(x?: number): void {
+    this.#editor.focusStart(x)
+  }
+
+  /**
+   * Focus and place cursor at the end of the last block.
+   * Pass `x` (client X) to land at the same horizontal column on the last visual line.
+   */
+  focusEnd(x?: number): void {
+    this.#editor.focusEnd(x)
+  }
+
+  /**
    * Remove the editor from the DOM and cancel any pending debounced events.
    *
    * @remarks

--- a/packages/block-editor/src/editor/DailyNoteHistory.test.ts
+++ b/packages/block-editor/src/editor/DailyNoteHistory.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi } from 'vitest'
+import { DailyNoteHistory } from './DailyNoteHistory'
+import { Blocks, TextBlock, BlockOffset } from '../blocks/blocks'
+import { Text } from '../text/text'
+import type { NoteProvider } from './NoteProvider'
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeProvider(): NoteProvider & { saveCalls: Array<{ date: string; blocks: unknown }> } {
+  const saveCalls: Array<{ date: string; blocks: unknown }> = []
+  return {
+    saveCalls,
+    load: vi.fn().mockResolvedValue(null),
+    save: vi.fn().mockImplementation((date: string, blocks: unknown) => {
+      saveCalls.push({ date, blocks })
+      return Promise.resolve()
+    }),
+  }
+}
+
+function makeBlocks(...texts: string[]): Blocks {
+  return Blocks.from(texts.map((t, i) => new TextBlock(`b${i}`, new Text(t, []), [])))
+}
+
+function sel(blockId: string, offset: number): BlockOffset {
+  return new BlockOffset(blockId, offset)
+}
+
+// ─── DailyNoteHistory ─────────────────────────────────────────────────────────
+
+describe('DailyNoteHistory', () => {
+  describe('initial state', () => {
+    it('canUndo is false', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      expect(h.canUndo()).toBe(false)
+    })
+
+    it('canRedo is false', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      expect(h.canRedo()).toBe(false)
+    })
+
+    it('throws on undo when empty', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      expect(() => h.undo()).toThrow()
+    })
+
+    it('throws on redo when empty', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      expect(() => h.redo()).toThrow()
+    })
+  })
+
+  describe('add', () => {
+    it('canUndo becomes true after add', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      h.add('2024-01-15', makeBlocks('before'), makeBlocks('after'), null, null)
+      expect(h.canUndo()).toBe(true)
+    })
+
+    it('canRedo remains false after add', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      h.add('2024-01-15', makeBlocks('before'), makeBlocks('after'), null, null)
+      expect(h.canRedo()).toBe(false)
+    })
+  })
+
+  describe('undo', () => {
+    it('returns noteId, blocksBefore, and selectionBefore', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      const before = makeBlocks('hello')
+      const after = makeBlocks('hello world')
+      const selBefore = sel('b0', 0)
+      h.add('2024-01-15', before, after, selBefore, sel('b0', 5))
+      const result = h.undo()
+      expect(result.noteId).toBe('2024-01-15')
+      expect(result.blocks).toBe(before)
+      expect(result.selection).toBe(selBefore)
+    })
+
+    it('calls provider.save with noteId and blocksBefore', () => {
+      const provider = makeProvider()
+      const h = new DailyNoteHistory(provider)
+      const before = makeBlocks('old')
+      const after = makeBlocks('new')
+      h.add('2024-01-15', before, after, null, null)
+      h.undo()
+      expect(provider.save).toHaveBeenCalledWith('2024-01-15', before.blocks)
+    })
+
+    it('canUndo becomes false after undoing the only entry', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      h.add('2024-01-15', makeBlocks('a'), makeBlocks('b'), null, null)
+      h.undo()
+      expect(h.canUndo()).toBe(false)
+    })
+
+    it('canRedo becomes true after undo', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      h.add('2024-01-15', makeBlocks('a'), makeBlocks('b'), null, null)
+      h.undo()
+      expect(h.canRedo()).toBe(true)
+    })
+
+    it('undo twice returns entries in reverse order', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      const b1 = makeBlocks('step1')
+      const b2 = makeBlocks('step2')
+      const b3 = makeBlocks('step3')
+      h.add('2024-01-15', b1, b2, null, null)
+      h.add('2024-01-15', b2, b3, null, null)
+      const r1 = h.undo()
+      expect(r1.blocks).toBe(b2)
+      const r2 = h.undo()
+      expect(r2.blocks).toBe(b1)
+    })
+  })
+
+  describe('redo', () => {
+    it('returns noteId, blocksAfter, and selectionAfter', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      const before = makeBlocks('before')
+      const after = makeBlocks('after')
+      const selAfter = sel('b0', 5)
+      h.add('2024-01-15', before, after, null, selAfter)
+      h.undo()
+      const result = h.redo()
+      expect(result.noteId).toBe('2024-01-15')
+      expect(result.blocks).toBe(after)
+      expect(result.selection).toBe(selAfter)
+    })
+
+    it('calls provider.save with noteId and blocksAfter', () => {
+      const provider = makeProvider()
+      const h = new DailyNoteHistory(provider)
+      const before = makeBlocks('old')
+      const after = makeBlocks('new')
+      h.add('2024-01-15', before, after, null, null)
+      h.undo()
+      h.redo()
+      // undo called save with before, redo called save with after
+      expect(provider.save).toHaveBeenLastCalledWith('2024-01-15', after.blocks)
+    })
+
+    it('canRedo becomes false after redo', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      h.add('2024-01-15', makeBlocks('a'), makeBlocks('b'), null, null)
+      h.undo()
+      h.redo()
+      expect(h.canRedo()).toBe(false)
+    })
+
+    it('canUndo becomes true after redo', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      h.add('2024-01-15', makeBlocks('a'), makeBlocks('b'), null, null)
+      h.undo()
+      h.redo()
+      expect(h.canUndo()).toBe(true)
+    })
+  })
+
+  describe('redo stack cleared on add after undo', () => {
+    it('new add after undo clears redo', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      h.add('2024-01-15', makeBlocks('a'), makeBlocks('b'), null, null)
+      h.undo()
+      h.add('2024-01-15', makeBlocks('a'), makeBlocks('c'), null, null)
+      expect(h.canRedo()).toBe(false)
+    })
+  })
+
+  describe('cross-day scenarios', () => {
+    it('undo traverses entries across different notes in reverse order', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      const dayA_before = makeBlocks('a-before')
+      const dayA_after  = makeBlocks('a-after')
+      const dayB_before = makeBlocks('b-before')
+      const dayB_after  = makeBlocks('b-after')
+
+      h.add('2024-01-15', dayA_before, dayA_after, null, null)
+      h.add('2024-01-16', dayB_before, dayB_after, null, null)
+
+      const r1 = h.undo()
+      expect(r1.noteId).toBe('2024-01-16')
+      expect(r1.blocks).toBe(dayB_before)
+
+      const r2 = h.undo()
+      expect(r2.noteId).toBe('2024-01-15')
+      expect(r2.blocks).toBe(dayA_before)
+    })
+
+    it('redo applies changes to correct day after cross-day undo', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      const dayA_before = makeBlocks('a-before')
+      const dayA_after  = makeBlocks('a-after')
+      const dayB_before = makeBlocks('b-before')
+      const dayB_after  = makeBlocks('b-after')
+
+      h.add('2024-01-15', dayA_before, dayA_after, null, null)
+      h.add('2024-01-16', dayB_before, dayB_after, null, null)
+
+      h.undo()  // undoes day B
+      const r = h.redo()
+      expect(r.noteId).toBe('2024-01-16')
+      expect(r.blocks).toBe(dayB_after)
+    })
+
+    it('provider.save called with the correct noteId on cross-day undo', () => {
+      const provider = makeProvider()
+      const h = new DailyNoteHistory(provider)
+
+      h.add('2024-01-15', makeBlocks('a'), makeBlocks('a2'), null, null)
+      h.add('2024-01-16', makeBlocks('b'), makeBlocks('b2'), null, null)
+
+      h.undo()
+      expect(provider.save).toHaveBeenLastCalledWith('2024-01-16', expect.anything())
+      h.undo()
+      expect(provider.save).toHaveBeenLastCalledWith('2024-01-15', expect.anything())
+    })
+  })
+
+  describe('updateOrAdd', () => {
+    it('coalesces text changes for the same noteId and blockId', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      const base = makeBlocks('')
+      const mid  = makeBlocks('h')
+      const end  = makeBlocks('he')
+
+      h.updateOrAdd('2024-01-15', 'b0', base, mid, null, sel('b0', 1))
+      h.updateOrAdd('2024-01-15', 'b0', mid, end, null, sel('b0', 2))
+
+      // One entry — undo goes straight to base
+      const r = h.undo()
+      expect(r.blocks).toBe(base)
+      expect(h.canUndo()).toBe(false)
+    })
+
+    it('coalescing preserves original selectionBefore', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      const firstBefore = sel('b0', 0)
+      h.updateOrAdd('2024-01-15', 'b0', makeBlocks(''), makeBlocks('h'), firstBefore, sel('b0', 1))
+      h.updateOrAdd('2024-01-15', 'b0', makeBlocks('h'), makeBlocks('he'), sel('b0', 1), sel('b0', 2))
+
+      const r = h.undo()
+      expect(r.selection).toBe(firstBefore)
+    })
+
+    it('coalescing updates selectionAfter to the latest value', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      const lastAfter = sel('b0', 2)
+      h.updateOrAdd('2024-01-15', 'b0', makeBlocks(''), makeBlocks('h'), null, sel('b0', 1))
+      h.updateOrAdd('2024-01-15', 'b0', makeBlocks('h'), makeBlocks('he'), null, lastAfter)
+
+      h.undo()
+      const r = h.redo()
+      expect(r.selection).toBe(lastAfter)
+    })
+
+    it('does not coalesce when noteId differs', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      h.updateOrAdd('2024-01-15', 'b0', makeBlocks('a'), makeBlocks('ab'), null, null)
+      h.updateOrAdd('2024-01-16', 'b0', makeBlocks('x'), makeBlocks('xy'), null, null)
+
+      // Two separate entries
+      h.undo()
+      expect(h.canUndo()).toBe(true)
+    })
+
+    it('does not coalesce when blockId differs', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      const blocksAB = Blocks.from([
+        new TextBlock('b0', new Text('a', []), []),
+        new TextBlock('b1', new Text('x', []), []),
+      ])
+      const blocksAB2 = Blocks.from([
+        new TextBlock('b0', new Text('ab', []), []),
+        new TextBlock('b1', new Text('x', []), []),
+      ])
+      const blocksAB3 = Blocks.from([
+        new TextBlock('b0', new Text('ab', []), []),
+        new TextBlock('b1', new Text('xy', []), []),
+      ])
+
+      h.updateOrAdd('2024-01-15', 'b0', blocksAB, blocksAB2, null, null)
+      h.updateOrAdd('2024-01-15', 'b1', blocksAB2, blocksAB3, null, null)
+
+      h.undo()
+      expect(h.canUndo()).toBe(true)
+    })
+  })
+
+  describe('MAX_DEPTH cap', () => {
+    it('oldest entry is dropped when MAX_DEPTH is exceeded', () => {
+      const h = new DailyNoteHistory(makeProvider())
+      for (let i = 0; i <= DailyNoteHistory.MAX_DEPTH; i++) {
+        h.add('2024-01-15', makeBlocks(`step${i}`), makeBlocks(`step${i + 1}`), null, null)
+      }
+      expect(h.canUndo()).toBe(true)
+      expect(h.canRedo()).toBe(false)
+      for (let i = 0; i < DailyNoteHistory.MAX_DEPTH; i++) {
+        h.undo()
+      }
+      expect(h.canUndo()).toBe(false)
+    })
+  })
+})

--- a/packages/block-editor/src/editor/DailyNoteHistory.ts
+++ b/packages/block-editor/src/editor/DailyNoteHistory.ts
@@ -1,0 +1,166 @@
+import type { Blocks, BlockId } from '../blocks/blocks'
+import type { BlockSelection } from './events'
+import type { NoteProvider } from './NoteProvider'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Entry {
+  noteId: string
+  blocksBefore: Blocks
+  blocksAfter: Blocks
+  selectionBefore: BlockSelection | null
+  selectionAfter: BlockSelection | null
+  /**
+   * Coalesce key for text-change merging.
+   * Set to `"${noteId}:${blockId}"` for single-block text changes,
+   * `null` for structural changes that must not be merged.
+   */
+  coalesceKey: string | null
+}
+
+// ─── DailyNoteHistory ─────────────────────────────────────────────────────────
+
+/**
+ * Cross-day undo/redo history for a journal-style editor.
+ *
+ * @remarks
+ * Each entry stores a `noteId` (ISO date string), a full `Blocks` snapshot
+ * before and after the change, and optional selection positions for cursor
+ * restoration. Undo/redo automatically calls `provider.save` so the
+ * persisted note is always consistent with the current undo position.
+ *
+ * Unlike `BlockHistory`, which reconstructs state from a change-event log,
+ * `DailyNoteHistory` stores explicit snapshots. This allows a single stack
+ * to span multiple notes without needing a per-note base.
+ *
+ * @example
+ * const history = new DailyNoteHistory(provider)
+ * history.add('2024-01-15', blocksBeforeEdit, blocksAfterEdit, selBefore, selAfter)
+ * const { noteId, blocks, selection } = history.undo()
+ * // noteId tells the caller which section to re-render
+ */
+export class DailyNoteHistory {
+  static readonly MAX_DEPTH = 100
+
+  #provider: NoteProvider
+  #entries: Entry[] = []
+  #pointer = 0
+
+  constructor(provider: NoteProvider) {
+    this.#provider = provider
+  }
+
+  canUndo(): boolean {
+    return this.#pointer > 0
+  }
+
+  canRedo(): boolean {
+    return this.#pointer < this.#entries.length
+  }
+
+  /**
+   * Record a structural change (Enter, Backspace, indent, inline toggle, etc.)
+   *
+   * @param noteId - ISO date of the affected note.
+   * @param blocksBefore - Full `Blocks` snapshot before the change.
+   * @param blocksAfter - Full `Blocks` snapshot after the change.
+   * @param selectionBefore - Cursor/selection before the change, for restoration on undo.
+   * @param selectionAfter - Cursor/selection after the change, for restoration on redo.
+   */
+  add(
+    noteId: string,
+    blocksBefore: Blocks,
+    blocksAfter: Blocks,
+    selectionBefore: BlockSelection | null,
+    selectionAfter: BlockSelection | null,
+  ): void {
+    // Clear redo stack
+    this.#entries.splice(this.#pointer)
+    this.#entries.push({ noteId, blocksBefore, blocksAfter, selectionBefore, selectionAfter, coalesceKey: null })
+    this.#pointer++
+    // Cap at MAX_DEPTH
+    if (this.#entries.length > DailyNoteHistory.MAX_DEPTH) {
+      this.#entries.shift()
+      this.#pointer--
+    }
+  }
+
+  /**
+   * Record or coalesce a single-block text change.
+   *
+   * @remarks
+   * When the previous entry targets the same `noteId` and `blockId`, the
+   * entry is updated in-place: the original `blocksBefore` and
+   * `selectionBefore` are preserved (burst-start state), while `blocksAfter`
+   * and `selectionAfter` are updated to the latest values. This groups rapid
+   * character-by-character typing into a single undoable step.
+   *
+   * @param noteId - ISO date of the affected note.
+   * @param blockId - ID of the block that received the text change.
+   * @param blocksBefore - Full `Blocks` snapshot before this change.
+   * @param blocksAfter - Full `Blocks` snapshot after this change.
+   */
+  updateOrAdd(
+    noteId: string,
+    blockId: BlockId,
+    blocksBefore: Blocks,
+    blocksAfter: Blocks,
+    selectionBefore: BlockSelection | null,
+    selectionAfter: BlockSelection | null,
+  ): void {
+    const coalesceKey = `${noteId}:${blockId}`
+    const lastEntry = this.#pointer > 0 ? this.#entries[this.#pointer - 1] : null
+
+    if (lastEntry && lastEntry.coalesceKey === coalesceKey) {
+      // Coalesce: preserve original blocksBefore and selectionBefore
+      this.#entries[this.#pointer - 1] = {
+        ...lastEntry,
+        blocksAfter,
+        selectionAfter,
+      }
+    } else {
+      this.add(noteId, blocksBefore, blocksAfter, selectionBefore, selectionAfter)
+      this.#entries[this.#pointer - 1].coalesceKey = coalesceKey
+    }
+  }
+
+  /**
+   * Undo the most recent change.
+   *
+   * @remarks
+   * Restores `blocksBefore` for the affected note and fires `provider.save`
+   * as a side effect. The `noteId` in the return value tells the caller which
+   * day section to re-render.
+   *
+   * @throws {Error} When there is nothing to undo.
+   * @returns `{ noteId, blocks, selection }` where `blocks` is the restored
+   *   snapshot and `selection` is the cursor position to restore.
+   */
+  undo(): { noteId: string; blocks: Blocks; selection: BlockSelection | null } {
+    if (!this.canUndo()) throw new Error('Nothing to undo')
+    const entry = this.#entries[this.#pointer - 1]
+    this.#pointer--
+    this.#provider.save(entry.noteId, entry.blocksBefore.blocks)
+    return { noteId: entry.noteId, blocks: entry.blocksBefore, selection: entry.selectionBefore }
+  }
+
+  /**
+   * Redo the most recently undone change.
+   *
+   * @remarks
+   * Reapplies `blocksAfter` for the affected note and fires `provider.save`.
+   * The `noteId` in the return value identifies the correct day section to
+   * re-render, which may differ from the currently active section.
+   *
+   * @throws {Error} When there is nothing to redo.
+   * @returns `{ noteId, blocks, selection }` where `blocks` is the reapplied
+   *   snapshot and `selection` is the cursor position to restore.
+   */
+  redo(): { noteId: string; blocks: Blocks; selection: BlockSelection | null } {
+    if (!this.canRedo()) throw new Error('Nothing to redo')
+    const entry = this.#entries[this.#pointer]
+    this.#pointer++
+    this.#provider.save(entry.noteId, entry.blocksAfter.blocks)
+    return { noteId: entry.noteId, blocks: entry.blocksAfter, selection: entry.selectionAfter }
+  }
+}

--- a/packages/block-editor/src/editor/DailyNoteScrollView.test.ts
+++ b/packages/block-editor/src/editor/DailyNoteScrollView.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { DailyNoteScrollView } from './DailyNoteScrollView'
+import type { NoteProvider } from './NoteProvider'
+
+// ─── IntersectionObserver mock ────────────────────────────────────────────────
+
+type IoCallback = (entries: IntersectionObserverEntry[]) => void
+
+class MockIntersectionObserver implements IntersectionObserver {
+  static instances: MockIntersectionObserver[] = []
+
+  readonly root = null
+  readonly rootMargin = ''
+  readonly thresholds = []
+
+  #callback: IoCallback
+  #targets: Element[] = []
+
+  constructor(callback: IoCallback) {
+    this.#callback = callback
+    MockIntersectionObserver.instances.push(this)
+  }
+
+  observe(target: Element): void {
+    this.#targets.push(target)
+  }
+
+  unobserve(target: Element): void {
+    this.#targets = this.#targets.filter(t => t !== target)
+  }
+
+  disconnect(): void {
+    this.#targets = []
+  }
+
+  takeRecords(): IntersectionObserverEntry[] { return [] }
+
+  /** Test helper: simulate a target becoming visible. */
+  triggerIntersect(target: Element): void {
+    this.#callback([{
+      target,
+      isIntersecting: true,
+      intersectionRatio: 1,
+      boundingClientRect: target.getBoundingClientRect(),
+      intersectionRect: target.getBoundingClientRect(),
+      rootBounds: null,
+      time: Date.now(),
+    }])
+  }
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function makeProvider(): NoteProvider {
+  return {
+    load: vi.fn().mockResolvedValue(null),
+    save: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeContainer(): HTMLElement {
+  const div = document.createElement('div')
+  document.body.appendChild(div)
+  return div
+}
+
+/** Set a DOM selection that spans from one day section to another. */
+function setCrossDayRange(container: HTMLElement, startDate: string, endDate: string): void {
+  const startBlock = container.querySelector(`[data-date="${startDate}"] .daily-note-content .block`)!
+  const endBlock   = container.querySelector(`[data-date="${endDate}"] .daily-note-content .block`)!
+  const startEl = startBlock.querySelector('p, h1, h2, h3')!
+  const endEl   = endBlock.querySelector('p, h1, h2, h3')!
+  const range = document.createRange()
+  range.setStart(startEl, 0)
+  range.setEnd(endEl, 0)
+  window.getSelection()!.removeAllRanges()
+  window.getSelection()!.addRange(range)
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('DailyNoteScrollView', () => {
+  const containers: HTMLElement[] = []
+  const views: DailyNoteScrollView[] = []
+
+  beforeEach(() => {
+    MockIntersectionObserver.instances.length = 0
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+  })
+
+  afterEach(() => {
+    views.forEach(v => v.destroy())
+    containers.forEach(c => c.remove())
+    views.length = 0
+    containers.length = 0
+    vi.unstubAllGlobals()
+  })
+
+  function make(
+    provider: NoteProvider = makeProvider(),
+    centerDate = '2024-01-15',
+    opts: { windowSize?: number } = {},
+  ): { view: DailyNoteScrollView; container: HTMLElement } {
+    const container = makeContainer()
+    containers.push(container)
+    const view = new DailyNoteScrollView(container, provider, centerDate, opts)
+    views.push(view)
+    return { view, container }
+  }
+
+  // ─── Single contenteditable ────────────────────────────────────────────────
+
+  it('uses a single contenteditable for all day sections', () => {
+    const { container } = make()
+    expect(container.querySelectorAll('[contenteditable="true"]').length).toBe(1)
+  })
+
+  it('renders block elements inside every day section', () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+    const sections = Array.from(container.querySelectorAll('.daily-note-section'))
+    expect(sections.length).toBe(3)
+    for (const section of sections) {
+      expect(section.querySelectorAll('.block').length).toBeGreaterThan(0)
+    }
+  })
+
+  it('renders non-editable date headers inside each section', () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+    const headers = Array.from(container.querySelectorAll('.daily-note-header'))
+    expect(headers.length).toBe(3)
+    for (const header of headers) {
+      expect((header as HTMLElement).contentEditable).toBe('false')
+    }
+  })
+
+  // ─── Backspace boundary protection ────────────────────────────────────────
+
+  it('Backspace at offset 0 of the first block of a section does not cross into the previous section', async () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+    // sections: 2024-01-14 | 2024-01-15 | 2024-01-16
+
+    const editable = container.querySelector('[contenteditable="true"]') as HTMLElement
+    await vi.waitFor(() => expect(container.querySelectorAll('.block').length).toBeGreaterThan(0))
+
+    const blockCountBefore = container.querySelectorAll('.block').length
+
+    // Focus the first block of the middle section (2024-01-15)
+    const sections = Array.from(container.querySelectorAll('.daily-note-section'))
+    const middleSection = sections.find(s => s.getAttribute('data-date') === '2024-01-15')!
+    const content = middleSection.querySelector('.daily-note-content')!
+    const firstBlock = content.querySelector('.block')!
+    const p = firstBlock.querySelector('p, h1, h2, h3')!
+    const range = document.createRange()
+    range.setStart(p, 0)
+    range.setEnd(p, 0)
+    window.getSelection()!.removeAllRanges()
+    window.getSelection()!.addRange(range)
+
+    editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true }))
+
+    // Block count must not decrease — no cross-day merge
+    expect(container.querySelectorAll('.block').length).toBe(blockCountBefore)
+  })
+
+  // ─── Rendering ─────────────────────────────────────────────────────────────
+
+  it('renders the default window of 7 day sections', () => {
+    const { container } = make()
+    expect(container.querySelectorAll('.daily-note-section').length).toBe(7)
+  })
+
+  it('respects custom windowSize option', () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+    expect(container.querySelectorAll('.daily-note-section').length).toBe(3)
+  })
+
+  it('renders a section for centerDate', () => {
+    const { container } = make(makeProvider(), '2024-01-15')
+    const sections = Array.from(container.querySelectorAll('.daily-note-section'))
+    const dates = sections.map(s => s.getAttribute('data-date'))
+    expect(dates).toContain('2024-01-15')
+  })
+
+  it('renders sections for days before and after centerDate', () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+    const sections = Array.from(container.querySelectorAll('.daily-note-section'))
+    const dates = sections.map(s => s.getAttribute('data-date'))
+    expect(dates).toContain('2024-01-14')
+    expect(dates).toContain('2024-01-15')
+    expect(dates).toContain('2024-01-16')
+  })
+
+  it('loads notes via provider for each rendered section', () => {
+    const provider = makeProvider()
+    make(provider, '2024-01-15', { windowSize: 3 })
+    expect(provider.load).toHaveBeenCalledTimes(3)
+  })
+
+  // ─── Rolling window — scroll down ──────────────────────────────────────────
+
+  it('appends next day and removes oldest when bottom sentinel fires', () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+
+    const io = MockIntersectionObserver.instances[0]
+    const bottomSentinel = container.querySelector('.daily-note-sentinel-bottom')!
+    io.triggerIntersect(bottomSentinel)
+
+    const sections = Array.from(container.querySelectorAll('.daily-note-section'))
+    expect(sections.length).toBe(3)
+    const dates = sections.map(s => s.getAttribute('data-date'))
+    expect(dates).not.toContain('2024-01-14')
+    expect(dates).toContain('2024-01-17')
+  })
+
+  // ─── Rolling window — scroll up ────────────────────────────────────────────
+
+  it('prepends previous day and removes newest when top sentinel fires', () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+
+    const io = MockIntersectionObserver.instances[0]
+    const topSentinel = container.querySelector('.daily-note-sentinel-top')!
+    io.triggerIntersect(topSentinel)
+
+    const sections = Array.from(container.querySelectorAll('.daily-note-section'))
+    expect(sections.length).toBe(3)
+    const dates = sections.map(s => s.getAttribute('data-date'))
+    expect(dates).not.toContain('2024-01-16')
+    expect(dates).toContain('2024-01-13')
+  })
+
+  it('renders sections in oldest-to-newest order after scrolling up', () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+    // initial: [2024-01-14, 2024-01-15, 2024-01-16]
+
+    const io = MockIntersectionObserver.instances[0]
+    const topSentinel = container.querySelector('.daily-note-sentinel-top')!
+    io.triggerIntersect(topSentinel)
+    // expected: [2024-01-13, 2024-01-14, 2024-01-15]
+
+    const sections = Array.from(container.querySelectorAll('.daily-note-section'))
+    const dates = sections.map(s => s.getAttribute('data-date'))
+    expect(dates).toEqual(['2024-01-13', '2024-01-14', '2024-01-15'])
+  })
+
+  it('renders sections in oldest-to-newest order after multiple scroll-up slides', () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+    // initial: [2024-01-14, 2024-01-15, 2024-01-16]
+
+    const io = MockIntersectionObserver.instances[0]
+    const topSentinel = container.querySelector('.daily-note-sentinel-top')!
+    io.triggerIntersect(topSentinel) // → [2024-01-13, 2024-01-14, 2024-01-15]
+    io.triggerIntersect(topSentinel) // → [2024-01-12, 2024-01-13, 2024-01-14]
+
+    const sections = Array.from(container.querySelectorAll('.daily-note-section'))
+    const dates = sections.map(s => s.getAttribute('data-date'))
+    expect(dates).toEqual(['2024-01-12', '2024-01-13', '2024-01-14'])
+  })
+
+  // ─── Cross-day selection ──────────────────────────────────────────────────
+
+  it('cross-day Backspace calls preventDefault and preserves all day sections', async () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+    const editable = container.querySelector('[contenteditable="true"]') as HTMLElement
+    await vi.waitFor(() => expect(container.querySelectorAll('.block').length).toBe(3))
+
+    setCrossDayRange(container, '2024-01-14', '2024-01-15')
+
+    const event = new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true })
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+    editable.dispatchEvent(event)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+    expect(container.querySelectorAll('.daily-note-section').length).toBe(3)
+    expect(container.querySelector('[data-date="2024-01-14"]')).toBeTruthy()
+    expect(container.querySelector('[data-date="2024-01-15"]')).toBeTruthy()
+  })
+
+  it('cross-day Backspace places the cursor in the end day', async () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+    const editable = container.querySelector('[contenteditable="true"]') as HTMLElement
+    await vi.waitFor(() => expect(container.querySelectorAll('.block').length).toBe(3))
+
+    setCrossDayRange(container, '2024-01-14', '2024-01-15')
+    editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true }))
+
+    const endSection = container.querySelector('[data-date="2024-01-15"]')!
+    const endContent = endSection.querySelector('.daily-note-content')!
+    const anchor = window.getSelection()!.anchorNode
+    expect(endContent.contains(anchor)).toBe(true)
+  })
+
+  it('cross-day Enter calls preventDefault and preserves all day sections', async () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+    const editable = container.querySelector('[contenteditable="true"]') as HTMLElement
+    await vi.waitFor(() => expect(container.querySelectorAll('.block').length).toBe(3))
+
+    setCrossDayRange(container, '2024-01-14', '2024-01-15')
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+    editable.dispatchEvent(event)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+    expect(container.querySelectorAll('.daily-note-section').length).toBe(3)
+  })
+
+  it('cross-day character input calls preventDefault and preserves all day sections', async () => {
+    const { container } = make(makeProvider(), '2024-01-15', { windowSize: 3 })
+    const editable = container.querySelector('[contenteditable="true"]') as HTMLElement
+    await vi.waitFor(() => expect(container.querySelectorAll('.block').length).toBe(3))
+
+    setCrossDayRange(container, '2024-01-14', '2024-01-15')
+
+    const event = new KeyboardEvent('keydown', { key: 'x', bubbles: true, cancelable: true })
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+    editable.dispatchEvent(event)
+
+    expect(preventDefaultSpy).toHaveBeenCalled()
+    expect(container.querySelectorAll('.daily-note-section').length).toBe(3)
+  })
+
+  // ─── Lifecycle ─────────────────────────────────────────────────────────────
+
+  it('destroy disconnects the IntersectionObserver', () => {
+    const { view } = make()
+    const io = MockIntersectionObserver.instances[0]
+    const disconnectSpy = vi.spyOn(io, 'disconnect')
+    view.destroy()
+    views.splice(views.indexOf(view), 1)
+    expect(disconnectSpy).toHaveBeenCalled()
+  })
+})

--- a/packages/block-editor/src/editor/DailyNoteScrollView.ts
+++ b/packages/block-editor/src/editor/DailyNoteScrollView.ts
@@ -1,0 +1,820 @@
+import { Blocks, BlockOffset, BlockRange, BlockDataChanged, type BlockId } from '../blocks/blocks'
+import type { NoteProvider } from './NoteProvider'
+import type { BlockSelection } from './events'
+import { BlockRenderer, getBlockElement, getBlockElementContent, getCharOffset } from './BlockRenderer'
+import { BlockHistory } from './BlockHistory'
+import { BlockEventEmitter } from './BlockEventEmitter'
+import { InputHandler } from './InputHandler'
+import { DailyNoteHistory } from './DailyNoteHistory'
+import './daily-note-scroll-view.css'
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+function addDays(isoDate: string, days: number): string {
+  const [year, month, day] = isoDate.split('-').map(Number)
+  const d = new Date(year, month - 1, day)
+  d.setDate(d.getDate() + days)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${dd}`
+}
+
+function formatDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-').map(Number)
+  return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+// ─── Options ──────────────────────────────────────────────────────────────────
+
+export interface DailyNoteScrollViewOptions {
+  /** Number of day sections to keep in the DOM. Default 7 (today ±3). */
+  windowSize?: number
+  dataUpdateDebounceMs?: number
+  dataUpdateMaxWaitMs?: number
+  /**
+   * Called with the ISO date strings of every section currently visible
+   * in the viewport, in document order, whenever that set changes.
+   *
+   * @param dates - ISO date strings of the visible sections, oldest → newest.
+   *
+   * @example
+   * onVisibleDatesChange: (dates) => {
+   *   const today = new Date().toISOString().slice(0, 10)
+   *   showJumpToToday = !dates.includes(today)
+   * }
+   */
+  onVisibleDatesChange?: (dates: readonly string[]) => void
+}
+
+// ─── Internal per-day state ───────────────────────────────────────────────────
+
+const DATA_EVENTS = ['blockCreated', 'blockDataUpdated', 'blockRemoved', 'blockMoved'] as const
+
+interface CrossDaySelection {
+  startDay: DayState
+  startBlockId: string
+  startOffset: number
+  endDay: DayState
+  endBlockId: string
+  endOffset: number
+  middleDays: DayState[]
+}
+
+interface DayState {
+  date: string
+  sectionEl: HTMLElement   // .daily-note-section wrapper
+  contentEl: HTMLElement   // .daily-note-content — BlockRenderer target
+  /** Mutable reference box so InputHandler closures always see the latest Blocks. */
+  ref: { blocks: Blocks }
+  history: BlockHistory
+  emitter: BlockEventEmitter
+  renderer: BlockRenderer
+  input: InputHandler
+}
+
+// ─── DailyNoteScrollView ──────────────────────────────────────────────────────
+
+/**
+ * Infinite-scroll journal rendered into a single `contenteditable` element.
+ *
+ * @remarks
+ * All day sections share one `<div contenteditable="true">`. Each section
+ * has a `<div contenteditable="false">` date header so the cursor moves
+ * freely across days while preventing header text from being edited.
+ *
+ * Sentinel elements outside the editable are observed by an
+ * `IntersectionObserver`; when a sentinel becomes visible the window slides
+ * in that direction — the oldest section is destroyed and a new one is added
+ * on the opposite end.
+ *
+ * Cross-day boundary protection is automatic: each day has its own `Blocks`
+ * state, so `InputHandler.handleBackspace` sees no previous block at offset 0
+ * of the first block and returns without merging.
+ *
+ * Undo/redo is managed by a single `DailyNoteHistory` instance that spans all
+ * loaded sections. Pressing Cmd/Ctrl+Z always undoes the most recent change
+ * regardless of which day it was in, and automatically saves the restored state
+ * via the `NoteProvider`.
+ */
+export class DailyNoteScrollView {
+  #provider: NoteProvider
+  #editable: HTMLElement               // the single shared contenteditable
+  #dates: string[]                     // oldest → newest
+  #dayStates: Map<string, DayState>    // date → state
+  #sections: Map<string, HTMLElement>  // date → sectionEl
+  #topSentinel: HTMLElement
+  #bottomSentinel: HTMLElement
+  #observer: IntersectionObserver
+  #visibilityObserver: IntersectionObserver | null = null
+  #visibleDates: Set<string> = new Set()
+  #scrollRoot: HTMLElement | null = null
+  #windowSize: number
+  #centerDate: string
+  #opts: DailyNoteScrollViewOptions
+  #composing = false
+  #destroyed = false
+  #dailyNoteHistory: DailyNoteHistory
+
+  constructor(
+    container: HTMLElement,
+    provider: NoteProvider,
+    centerDate: string,
+    opts: DailyNoteScrollViewOptions = {},
+  ) {
+    this.#provider = provider
+    this.#windowSize = opts.windowSize ?? 7
+    this.#centerDate = centerDate
+    this.#opts = opts
+    this.#dayStates = new Map()
+    this.#sections = new Map()
+    this.#dailyNoteHistory = new DailyNoteHistory(provider)
+
+    // Build initial date window centred on centerDate
+    const half = Math.floor(this.#windowSize / 2)
+    this.#dates = []
+    for (let i = -half; i <= half; i++) {
+      if (this.#dates.length < this.#windowSize) {
+        this.#dates.push(addDays(centerDate, i))
+      }
+    }
+    this.#dates = this.#dates.slice(0, this.#windowSize)
+
+    // Single shared contenteditable
+    this.#editable = document.createElement('div')
+    this.#editable.className = 'block-editor-editable'
+    this.#editable.contentEditable = 'true'
+    this.#editable.setAttribute('spellcheck', 'false')
+
+    // Sentinels live outside the editable so they don't interfere with editing
+    this.#topSentinel = document.createElement('div')
+    this.#topSentinel.className = 'daily-note-sentinel-top'
+    this.#bottomSentinel = document.createElement('div')
+    this.#bottomSentinel.className = 'daily-note-sentinel-bottom'
+
+    container.appendChild(this.#topSentinel)
+    container.appendChild(this.#editable)
+    container.appendChild(this.#bottomSentinel)
+
+    // Attach shared event handlers
+    this.#editable.addEventListener('keydown', (e) => this.#handleKeyDown(e))
+    this.#editable.addEventListener('input', () => this.#handleInput())
+    this.#editable.addEventListener('blur', () => this.#handleBlur())
+    this.#editable.addEventListener('compositionstart', () => this.#handleCompositionStart())
+    this.#editable.addEventListener('compositionend', () => this.#handleCompositionEnd())
+
+    // Mount initial sections
+    for (const date of this.#dates) {
+      this.#mountSection(date, 'append')
+    }
+
+    // The scroll root is the container's parent (e.g. .scroller). Using the
+    // viewport root would never fire because the sentinel elements are clipped
+    // inside the scroll container and never intersect the actual viewport.
+    const scrollRoot = container.parentElement
+    this.#scrollRoot = scrollRoot instanceof HTMLElement ? scrollRoot : null
+
+    // IntersectionObserver for infinite scroll
+    this.#observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue
+        if (entry.target === this.#topSentinel) this.#slideUp()
+        else if (entry.target === this.#bottomSentinel) this.#slideDown()
+      }
+    }, { root: scrollRoot })
+
+    // IntersectionObserver for viewport-visible date tracking
+    if (opts.onVisibleDatesChange) {
+      this.#visibilityObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+          const date = (entry.target as HTMLElement).dataset.date
+          if (!date) continue
+          if (entry.isIntersecting) {
+            this.#visibleDates.add(date)
+          } else {
+            this.#visibleDates.delete(date)
+          }
+        }
+        this.#notifyVisibleDates()
+      }, { root: scrollRoot })
+      for (const sectionEl of this.#sections.values()) {
+        this.#visibilityObserver.observe(sectionEl)
+      }
+    }
+
+    // Scroll to today's section, then start watching sentinels.
+    // Sentinel observation must begin only after the initial scroll position
+    // is set — at scrollTop=0 the top sentinel is visible, which would
+    // immediately trigger a spurious #slideUp and start an oscillation loop.
+    requestAnimationFrame(() => {
+      this.#sections.get(centerDate)?.scrollIntoView({ block: 'start', behavior: 'instant' })
+      this.#observer.observe(this.#topSentinel)
+      this.#observer.observe(this.#bottomSentinel)
+    })
+  }
+
+  destroy(): void {
+    if (this.#destroyed) return
+    this.#destroyed = true
+    this.#observer.disconnect()
+    this.#visibilityObserver?.disconnect()
+    for (const dayState of this.#dayStates.values()) {
+      dayState.emitter.cancelAll()
+    }
+  }
+
+  // ─── Private: section lifecycle ──────────────────────────────────────────────
+
+  #mountSection(date: string, position: 'append' | 'prepend'): void {
+    const sectionEl = document.createElement('div')
+    sectionEl.className = 'daily-note-section'
+    sectionEl.setAttribute('data-date', date)
+
+    // Non-editable date header
+    const headerEl = document.createElement('div')
+    headerEl.className = 'daily-note-header'
+    headerEl.contentEditable = 'false'
+
+    const dateSpan = document.createElement('span')
+    dateSpan.className = 'daily-note-header-date'
+    dateSpan.textContent = formatDate(date)
+    headerEl.appendChild(dateSpan)
+
+    const todayDate = new Date().toISOString().slice(0, 10)
+    if (date === todayDate) {
+      sectionEl.setAttribute('data-today', 'true')
+      const badge = document.createElement('span')
+      badge.className = 'daily-note-today-badge'
+      badge.textContent = 'today'
+      headerEl.appendChild(badge)
+    }
+
+    sectionEl.appendChild(headerEl)
+
+    // Blocks container — BlockRenderer target
+    const contentEl = document.createElement('div')
+    contentEl.className = 'daily-note-content'
+    sectionEl.appendChild(contentEl)
+
+    this.#visibilityObserver?.observe(sectionEl)
+
+    // Insert into shared editable
+    if (position === 'append') {
+      this.#editable.appendChild(sectionEl)
+    } else {
+      const firstSection = this.#sections.size > 0 ? this.#sections.get(this.#dates[0]) : null
+      if (firstSection) {
+        this.#editable.insertBefore(sectionEl, firstSection)
+      } else {
+        this.#editable.appendChild(sectionEl)
+      }
+    }
+
+    // Per-day state
+    const initialBlocks = Blocks.from([Blocks.createTextBlock()])
+    const ref: { blocks: Blocks } = { blocks: initialBlocks }
+    const history = new BlockHistory(initialBlocks)
+    const emitter = new BlockEventEmitter(
+      (id: BlockId) => {
+        try {
+          const block = ref.blocks.getBlock(id)
+          return { id, blockType: block.blockType, data: block.data }
+        } catch {
+          return null
+        }
+      },
+      {
+        debounceMs: this.#opts.dataUpdateDebounceMs ?? 1000,
+        maxWaitMs:  this.#opts.dataUpdateMaxWaitMs  ?? 10000,
+      },
+    )
+    const renderer = new BlockRenderer(contentEl)
+    const input = new InputHandler(
+      renderer,
+      () => ref.blocks,
+      (b) => { ref.blocks = b },
+      history,
+      emitter,
+    )
+
+    renderer.render(ref.blocks)
+
+    const dayState: DayState = { date, sectionEl, contentEl, ref, history, emitter, renderer, input }
+    this.#dayStates.set(date, dayState)
+    this.#sections.set(date, sectionEl)
+
+    // Load from provider
+    this.#provider.load(date).then((loaded) => {
+      if (this.#destroyed) return
+      if (loaded !== null) {
+        ref.blocks = Blocks.from(loaded)
+        renderer.render(ref.blocks)
+      }
+    })
+
+    // Auto-save on data changes
+    for (const event of DATA_EVENTS) {
+      emitter.addEventListener(event, () => {
+        this.#provider.save(date, ref.blocks.blocks)
+      })
+    }
+  }
+
+  #unmountSection(date: string): void {
+    const dayState = this.#dayStates.get(date)
+    if (dayState) {
+      dayState.emitter.flushAll()
+      dayState.emitter.cancelAll()
+      this.#dayStates.delete(date)
+    }
+    const sectionEl = this.#sections.get(date)
+    if (sectionEl) {
+      this.#visibilityObserver?.unobserve(sectionEl)
+      this.#visibleDates.delete(date)
+      sectionEl.remove()
+      this.#sections.delete(date)
+    }
+  }
+
+  /**
+   * Scroll to today's section. If today has been slid out of the window,
+   * reinitializes the window around today first.
+   */
+  scrollToToday(): void {
+    const todaySection = this.#sections.get(this.#centerDate)
+    if (todaySection) {
+      todaySection.scrollIntoView({ block: 'start', behavior: 'smooth' })
+      return
+    }
+
+    // Today is outside the current window — rebuild around it
+    const half = Math.floor(this.#windowSize / 2)
+    const newDates: string[] = []
+    for (let i = -half; i <= half; i++) {
+      if (newDates.length < this.#windowSize) newDates.push(addDays(this.#centerDate, i))
+    }
+
+    for (const date of [...this.#dates]) this.#unmountSection(date)
+    this.#dates = newDates.slice(0, this.#windowSize)
+    for (const date of this.#dates) this.#mountSection(date, 'append')
+
+    requestAnimationFrame(() => {
+      this.#sections.get(this.#centerDate)?.scrollIntoView({ block: 'start', behavior: 'instant' })
+    })
+  }
+
+  /** Slide window towards older dates (user scrolled up). */
+  #slideUp(): void {
+    const prevDate = addDays(this.#dates[0], -1)
+    this.#mountSection(prevDate, 'prepend')
+    this.#dates.unshift(prevDate)
+
+    const newEl = this.#sections.get(prevDate)
+    const newHeight = newEl?.offsetHeight ?? 0
+    if (this.#scrollRoot && newHeight > 0) {
+      this.#scrollRoot.scrollTo({ top: this.#scrollRoot.scrollTop + newHeight, behavior: 'instant' })
+    }
+
+    const removed = this.#dates.pop()!
+    this.#unmountSection(removed)
+  }
+
+  /** Slide window towards newer dates (user scrolled down). */
+  #slideDown(): void {
+    const nextDate = addDays(this.#dates[this.#dates.length - 1], 1)
+    this.#dates.push(nextDate)
+    this.#mountSection(nextDate, 'append')
+
+    const removed = this.#dates.shift()!
+    const removedEl = this.#sections.get(removed)
+    const removedHeight = removedEl?.offsetHeight ?? 0
+    this.#unmountSection(removed)
+    if (this.#scrollRoot && removedHeight > 0 && this.#scrollRoot.scrollTop >= removedHeight) {
+      this.#scrollRoot.scrollTo({ top: this.#scrollRoot.scrollTop - removedHeight, behavior: 'instant' })
+    }
+  }
+
+  #notifyVisibleDates(): void {
+    const ordered = this.#dates.filter((d) => this.#visibleDates.has(d))
+    this.#opts.onVisibleDatesChange?.(ordered)
+  }
+
+  // ─── Private: event routing ───────────────────────────────────────────────────
+
+  /** Walk up from `node` to find the `.daily-note-section[data-date]` ancestor. */
+  #getDayForNode(node: Node): DayState | null {
+    let current: Node | null = node
+    while (current) {
+      if (current.nodeType === Node.ELEMENT_NODE) {
+        const date = (current as Element).getAttribute?.('data-date')
+        if (date) return this.#dayStates.get(date) ?? null
+      }
+      current = current.parentNode
+    }
+    return null
+  }
+
+  /**
+   * Find the day state whose content element contains the current selection anchor.
+   * Returns null when the cursor is in a header or outside all sections.
+   */
+  #getActiveDayState(): DayState | null {
+    const domSel = window.getSelection()
+    if (!domSel || domSel.rangeCount === 0) return null
+    return this.#getDayForNode(domSel.getRangeAt(0).startContainer)
+  }
+
+  /** True when the DOM selection spans two different day sections. */
+  #isCrossDaySelection(): boolean {
+    const domSel = window.getSelection()
+    if (!domSel || domSel.isCollapsed || domSel.rangeCount === 0) return false
+    const a = this.#getDayForNode(domSel.anchorNode!)
+    const f = this.#getDayForNode(domSel.focusNode!)
+    return a !== null && f !== null && a !== f
+  }
+
+  /**
+   * Resolve a cross-day DOM selection into structured start/end state.
+   * Returns null if the selection is collapsed, same-day, or doesn't map to
+   * identifiable block elements.
+   */
+  #getCrossDaySelection(): CrossDaySelection | null {
+    const domSel = window.getSelection()
+    if (!domSel || domSel.isCollapsed || domSel.rangeCount === 0) return null
+
+    const anchorDay = this.#getDayForNode(domSel.anchorNode!)
+    const focusDay  = this.#getDayForNode(domSel.focusNode!)
+    if (!anchorDay || !focusDay || anchorDay === focusDay) return null
+
+    const anchorFirst = !!(
+      domSel.anchorNode!.compareDocumentPosition(domSel.focusNode!) &
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+
+    const startDay  = anchorFirst ? anchorDay  : focusDay
+    const startNode = anchorFirst ? domSel.anchorNode! : domSel.focusNode!
+    const startOff  = anchorFirst ? domSel.anchorOffset : domSel.focusOffset
+    const endDay    = anchorFirst ? focusDay   : anchorDay
+    const endNode   = anchorFirst ? domSel.focusNode!  : domSel.anchorNode!
+    const endOff    = anchorFirst ? domSel.focusOffset : domSel.anchorOffset
+
+    const startBlockEl = getBlockElement(startNode)
+    const endBlockEl   = getBlockElement(endNode)
+    if (!startBlockEl || !endBlockEl) return null
+
+    const startP = getBlockElementContent(startBlockEl)
+    const endP   = getBlockElementContent(endBlockEl)
+    const startCharOff = getCharOffset(startP, startNode, startOff)
+    const endCharOff   = getCharOffset(endP,   endNode,   endOff)
+    if (startCharOff === -1 || endCharOff === -1) return null
+
+    const startIdx = this.#dates.indexOf(startDay.date)
+    const endIdx   = this.#dates.indexOf(endDay.date)
+    const middleDays: DayState[] = []
+    for (let i = startIdx + 1; i < endIdx; i++) {
+      const d = this.#dayStates.get(this.#dates[i])
+      if (d) middleDays.push(d)
+    }
+
+    return {
+      startDay, startBlockId: startBlockEl.id, startOffset: startCharOff,
+      endDay,   endBlockId:   endBlockEl.id,   endOffset:   endCharOff,
+      middleDays,
+    }
+  }
+
+  /**
+   * Delete the cross-day selection:
+   * 1. Trim start day: keep content before selection start.
+   * 2. Clear middle days to a single empty block.
+   * 3. Trim end day: remove content before selection end.
+   *
+   * Returns the cursor `BlockOffset` in the end day.
+   */
+  #handleCrossDayDeletion(cs: CrossDaySelection): BlockOffset {
+    // 1. Trim start day
+    const startLastBlock = cs.startDay.ref.blocks.blocks.at(-1)!
+    const needsStartTrim =
+      cs.startBlockId !== startLastBlock.id ||
+      cs.startOffset !== startLastBlock.getLength()
+    if (needsStartTrim) {
+      cs.startDay.input.pendingSelectionBefore = null
+      cs.startDay.input.deleteRange(new BlockRange(
+        new BlockOffset(cs.startBlockId, cs.startOffset),
+        new BlockOffset(startLastBlock.id, startLastBlock.getLength()),
+      ))
+      cs.startDay.renderer.render(cs.startDay.ref.blocks)
+    }
+
+    // 2. Clear middle days
+    for (const mid of cs.middleDays) {
+      const cleared = Blocks.from([Blocks.createTextBlock()])
+      const old = mid.ref.blocks
+      mid.ref.blocks = cleared
+      mid.renderer.render(cleared)
+      mid.emitter.dispatchChanges(Blocks.diff(old, cleared))
+    }
+
+    // 3. Trim end day
+    const endFirstBlock = cs.endDay.ref.blocks.blocks[0]
+    const endRangeCollapsed =
+      endFirstBlock.id === cs.endBlockId && cs.endOffset === 0
+    if (!endRangeCollapsed) {
+      cs.endDay.input.pendingSelectionBefore = null
+      const cursor = cs.endDay.input.deleteRange(new BlockRange(
+        new BlockOffset(endFirstBlock.id, 0),
+        new BlockOffset(cs.endBlockId, cs.endOffset),
+      ))
+      cs.endDay.renderer.render(cs.endDay.ref.blocks, cursor)
+      return cursor
+    }
+    const cursor = new BlockOffset(endFirstBlock.id, 0)
+    cs.endDay.renderer.render(cs.endDay.ref.blocks, cursor)
+    return cursor
+  }
+
+  #handleCrossDayEnter(cs: CrossDaySelection): void {
+    this.#handleCrossDayDeletion(cs)
+  }
+
+  #handleCrossDayCharInput(cs: CrossDaySelection, char: string): void {
+    const cursor = this.#handleCrossDayDeletion(cs)
+    const state = cs.endDay.ref.blocks
+    const block = state.getBlock(cursor.blockId)
+    const newText = block.getText().insert(cursor.offset, char)
+    const newCursor = new BlockOffset(cursor.blockId, cursor.offset + 1)
+    cs.endDay.ref.blocks = state.update(cursor.blockId, newText)
+    cs.endDay.renderer.render(cs.endDay.ref.blocks, newCursor)
+    cs.endDay.emitter.scheduleDataUpdated(cursor.blockId)
+  }
+
+  #handleBlur(): void {
+    for (const dayState of this.#dayStates.values()) {
+      dayState.emitter.flushAll()
+    }
+  }
+
+  #handleCompositionStart(): void {
+    const dayState = this.#getActiveDayState()
+    if (!dayState) return
+    const sel = dayState.renderer.getSelection()
+    dayState.input.pendingSelectionBefore = sel
+    if (sel instanceof BlockRange) {
+      const cursor = dayState.input.deleteRange(sel)
+      dayState.renderer.render(dayState.ref.blocks, cursor)
+    }
+    dayState.input.composing = true
+    this.#composing = true
+  }
+
+  #handleCompositionEnd(): void {
+    this.#composing = false
+    const dayState = this.#getActiveDayState()
+    if (!dayState) return
+    dayState.input.composing = false
+    dayState.input.handleInput()
+  }
+
+  #handleInput(): void {
+    if (this.#composing) return
+    const dayState = this.#getActiveDayState()
+    if (!dayState) return
+
+    // Capture before-state for DailyNoteHistory
+    const blocksBefore = dayState.ref.blocks
+    const selBefore = dayState.input.pendingSelectionBefore
+    // Get blockId from the current selection (set by the browser's input event)
+    const currentSel = dayState.renderer.getSelection()
+    const blockId = currentSel instanceof BlockOffset ? currentSel.blockId : null
+
+    dayState.input.handleInput()
+
+    // Record in DailyNoteHistory if state changed
+    const blocksAfter = dayState.ref.blocks
+    if (blocksAfter !== blocksBefore) {
+      const selAfter = dayState.renderer.getSelection()
+      const diff = Blocks.diff(blocksBefore, blocksAfter)
+      if (diff.length === 1 && diff[0] instanceof BlockDataChanged && blockId) {
+        // Single text change — coalesce with previous entry for the same block
+        this.#dailyNoteHistory.updateOrAdd(dayState.date, blockId, blocksBefore, blocksAfter, selBefore, selAfter)
+      } else {
+        // InputRule match or other multi-change — record as structural
+        this.#dailyNoteHistory.add(dayState.date, blocksBefore, blocksAfter, selBefore, selAfter)
+      }
+    }
+  }
+
+  #handleKeyDown(e: KeyboardEvent): void {
+    if (this.#composing) return
+
+    // Undo: Ctrl/Cmd+Z — delegates to global DailyNoteHistory
+    if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key.toLowerCase() === 'z') {
+      if (this.#dailyNoteHistory.canUndo()) {
+        e.preventDefault()
+        const { noteId, blocks: newBlocks, selection } = this.#dailyNoteHistory.undo()
+        const dayState = this.#dayStates.get(noteId)
+        if (dayState) {
+          const oldBlocks = dayState.ref.blocks
+          dayState.ref.blocks = newBlocks
+          dayState.renderer.render(newBlocks, selection ?? undefined)
+          dayState.emitter.dispatchChanges(Blocks.diff(oldBlocks, newBlocks))
+        }
+      }
+      return
+    }
+
+    // Redo: Ctrl/Cmd+Shift+Z or Ctrl+Y — delegates to global DailyNoteHistory
+    if (
+      ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'z') ||
+      (e.ctrlKey && !e.metaKey && e.key.toLowerCase() === 'y')
+    ) {
+      if (this.#dailyNoteHistory.canRedo()) {
+        e.preventDefault()
+        const { noteId, blocks: newBlocks, selection } = this.#dailyNoteHistory.redo()
+        const dayState = this.#dayStates.get(noteId)
+        if (dayState) {
+          const oldBlocks = dayState.ref.blocks
+          dayState.ref.blocks = newBlocks
+          dayState.renderer.render(newBlocks, selection ?? undefined)
+          dayState.emitter.dispatchChanges(Blocks.diff(oldBlocks, newBlocks))
+        }
+      }
+      return
+    }
+
+    // Cross-day selection: block destructive operations that would merge sections
+    if (this.#isCrossDaySelection()) {
+      if (e.key === 'Backspace' || e.key === 'Delete') {
+        e.preventDefault()
+        const cs = this.#getCrossDaySelection()
+        if (cs) this.#handleCrossDayDeletion(cs)
+        return
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        const cs = this.#getCrossDaySelection()
+        if (cs) this.#handleCrossDayEnter(cs)
+        return
+      }
+      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault()
+        const cs = this.#getCrossDaySelection()
+        if (cs) this.#handleCrossDayCharInput(cs, e.key)
+        return
+      }
+    }
+
+    const dayState = this.#getActiveDayState()
+    if (!dayState) return
+
+    const sel = dayState.renderer.getSelection()
+    dayState.input.pendingSelectionBefore = sel
+
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      if (sel) {
+        const blocksBefore = dayState.ref.blocks
+        dayState.input.handleEnter(sel)
+        const blocksAfter = dayState.ref.blocks
+        if (blocksAfter !== blocksBefore) {
+          const selAfter = dayState.renderer.getSelection()
+          this.#dailyNoteHistory.add(dayState.date, blocksBefore, blocksAfter, sel, selAfter)
+        }
+      }
+      return
+    }
+
+    if (e.key === 'Tab') {
+      e.preventDefault()
+      if (sel) {
+        const fromId = sel instanceof BlockRange ? sel.start.blockId : sel.blockId
+        const toId   = sel instanceof BlockRange ? sel.end.blockId   : sel.blockId
+        this.#applyBlocksChange(dayState, (b) => e.shiftKey ? b.unindent(fromId, toId) : b.indent(fromId, toId), sel)
+      }
+      return
+    }
+
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'b') {
+      e.preventDefault()
+      if (sel instanceof BlockRange) {
+        this.#applyBlocksChange(dayState, (b) => b.toggleInline(sel, 'Bold'), sel)
+      }
+      return
+    }
+
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'i') {
+      e.preventDefault()
+      if (sel instanceof BlockRange) {
+        this.#applyBlocksChange(dayState, (b) => b.toggleInline(sel, 'Italic'), sel)
+      }
+      return
+    }
+
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'u') {
+      e.preventDefault()
+      if (sel instanceof BlockRange) {
+        this.#applyBlocksChange(dayState, (b) => b.toggleInline(sel, 'Underline'), sel)
+      }
+      return
+    }
+
+    if (e.key === 'Backspace') {
+      if (sel instanceof BlockRange) {
+        e.preventDefault()
+        const blocksBefore = dayState.ref.blocks
+        dayState.input.handleBackspace(sel)
+        const blocksAfter = dayState.ref.blocks
+        if (blocksAfter !== blocksBefore) {
+          const selAfter = dayState.renderer.getSelection()
+          this.#dailyNoteHistory.add(dayState.date, blocksBefore, blocksAfter, sel, selAfter)
+        }
+        return
+      }
+      if (sel instanceof BlockOffset && sel.offset === 0) {
+        e.preventDefault()
+        const blocksBefore = dayState.ref.blocks
+        dayState.input.handleBackspace(sel)
+        const blocksAfter = dayState.ref.blocks
+        if (blocksAfter !== blocksBefore) {
+          const selAfter = dayState.renderer.getSelection()
+          this.#dailyNoteHistory.add(dayState.date, blocksBefore, blocksAfter, sel, selAfter)
+        }
+        return
+      }
+      return
+    }
+
+    if (e.key === 'Delete') {
+      if (sel instanceof BlockRange) {
+        e.preventDefault()
+        const blocksBefore = dayState.ref.blocks
+        dayState.input.handleDelete(sel)
+        const blocksAfter = dayState.ref.blocks
+        if (blocksAfter !== blocksBefore) {
+          const selAfter = dayState.renderer.getSelection()
+          this.#dailyNoteHistory.add(dayState.date, blocksBefore, blocksAfter, sel, selAfter)
+        }
+        return
+      }
+      if (sel instanceof BlockOffset) {
+        const block = dayState.ref.blocks.getBlock(sel.blockId)
+        if (sel.offset === block.getLength()) {
+          e.preventDefault()
+          const blocksBefore = dayState.ref.blocks
+          dayState.input.handleDelete(sel)
+          const blocksAfter = dayState.ref.blocks
+          if (blocksAfter !== blocksBefore) {
+            const selAfter = dayState.renderer.getSelection()
+            this.#dailyNoteHistory.add(dayState.date, blocksBefore, blocksAfter, sel, selAfter)
+          }
+          return
+        }
+      }
+      return
+    }
+
+    // Printable char with range selection — delete range then insert char
+    if (
+      sel instanceof BlockRange &&
+      e.key.length === 1 &&
+      !e.ctrlKey &&
+      !e.metaKey &&
+      !e.altKey
+    ) {
+      e.preventDefault()
+      const blocksBefore = dayState.ref.blocks
+      dayState.input.insertCharOverRange(sel, e.key)
+      const blocksAfter = dayState.ref.blocks
+      if (blocksAfter !== blocksBefore) {
+        const selAfter = dayState.renderer.getSelection()
+        this.#dailyNoteHistory.add(dayState.date, blocksBefore, blocksAfter, sel, selAfter)
+      }
+      return
+    }
+  }
+
+  // ─── Private: state mutation helpers ─────────────────────────────────────────
+
+  #applyBlocksChange(
+    dayState: DayState,
+    mutate: (b: Blocks) => Blocks,
+    sel: BlockSelection,
+  ): void {
+    const oldBlocks = dayState.ref.blocks
+    dayState.ref.blocks = mutate(oldBlocks)
+    dayState.renderer.render(dayState.ref.blocks, sel)
+    const changes = Blocks.diff(oldBlocks, dayState.ref.blocks)
+    if (changes.length > 0) {
+      const selAfter = dayState.renderer.getSelection()
+      dayState.history.add(changes, dayState.input.pendingSelectionBefore, selAfter)
+      this.#dailyNoteHistory.add(dayState.date, oldBlocks, dayState.ref.blocks, dayState.input.pendingSelectionBefore, selAfter)
+    }
+    dayState.input.pendingSelectionBefore = null
+    dayState.emitter.dispatchChanges(changes)
+  }
+}

--- a/packages/block-editor/src/editor/daily-note-editor.css
+++ b/packages/block-editor/src/editor/daily-note-editor.css
@@ -4,12 +4,23 @@
 }
 
 .daily-note-header {
-  font-weight: 600;
-  font-size: 0.75rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-weight: 700;
+  font-size: 0.875rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  opacity: 0.5;
-  padding-bottom: 0.5rem;
+  opacity: 0.7;
+  padding-bottom: 1rem;
   user-select: none;
   pointer-events: none;
+}
+
+.daily-note-today-badge {
+  font-size: 0.75em;
+  letter-spacing: 0.05em;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 0.1em 0.55em;
 }

--- a/packages/block-editor/src/editor/daily-note-scroll-view.css
+++ b/packages/block-editor/src/editor/daily-note-scroll-view.css
@@ -1,0 +1,25 @@
+.daily-note-scroll-view {
+  display: flex;
+  flex-direction: column;
+}
+
+.daily-note-sentinel-top,
+.daily-note-sentinel-bottom {
+  height: 1px;
+  flex-shrink: 0;
+}
+
+.daily-note-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.daily-note-section + .daily-note-section {
+  margin-top: 3rem;
+  padding-top: 2.5rem;
+  border-top: 1px solid rgba(0 0 0 / 0.08);
+}
+
+[data-theme="dark"] .daily-note-section + .daily-note-section {
+  border-top-color: rgba(255 255 255 / 0.1);
+}

--- a/packages/block-editor/src/editor/events.ts
+++ b/packages/block-editor/src/editor/events.ts
@@ -26,6 +26,20 @@ export interface BlockEditorOptions {
    * @default 'previous-highlight'
    */
   highlightStorageKey?: string
+  /**
+   * Called when ArrowUp is pressed with the cursor on the first visual line of the
+   * first block. Lets a container (e.g. `DailyNoteScrollView`) move focus to the
+   * previous section. `x` is the client X coordinate of the cursor for same-column
+   * placement in the destination section.
+   */
+  onTopBoundaryEscape?: (x: number) => void
+  /**
+   * Called when ArrowDown is pressed with the cursor on the last visual line of the
+   * last block. Lets a container (e.g. `DailyNoteScrollView`) move focus to the
+   * next section. `x` is the client X coordinate of the cursor for same-column
+   * placement in the destination section.
+   */
+  onBottomBoundaryEscape?: (x: number) => void
 }
 
 export const BLOCK_EDITOR_EVENT_NAMES = [

--- a/packages/block-editor/src/index.ts
+++ b/packages/block-editor/src/index.ts
@@ -3,6 +3,9 @@ export { BlockEditor } from "./editor/BlockEditor";
 export { BlockRenderer } from "./editor/BlockRenderer";
 export { InputHandler } from "./editor/InputHandler";
 export { DailyNoteEditor } from "./editor/DailyNoteEditor";
+export { DailyNoteScrollView } from "./editor/DailyNoteScrollView";
+export type { DailyNoteScrollViewOptions } from "./editor/DailyNoteScrollView";
+export { DailyNoteHistory } from "./editor/DailyNoteHistory";
 export type { NoteProvider } from "./editor/NoteProvider";
 export { BLOCK_EDITOR_EVENT_NAMES } from "./editor/events"
 export type {


### PR DESCRIPTION
## Summary

Extracts `BlockRenderer` and `InputHandler` from `BlockEditor` into standalone composable classes, then builds on top to add `DailyNoteEditor`, `DailyNoteScrollView`, and `DailyNoteHistory` — a cross-day undo/redo mechanism that spans the entire journal session.

## Why

`BlockEditor` was a monolithic class that mixed rendering, input handling, and editor orchestration. Decomposing these responsibilities into `BlockRenderer` and `InputHandler` lets `DailyNoteScrollView` share the same rendering and input logic across multiple day sections without duplicating code.

`DailyNoteHistory` (closes #65) solves a UX gap: pressing Cmd+Z previously only undid changes in the currently active day section. With a single shared history stack, undo/redo works across the entire journal session — a change made in yesterday's note can be undone even when today's section is focused.

## Changes

- **`BlockRenderer`** — owns DOM rendering and selection save/restore; extracted from `BlockEditor`
- **`InputHandler`** — owns keydown/input/composition event logic; extracted from `BlockEditor`; composed into both `BlockEditor` and `DailyNoteScrollView`
- **`BlockEventEmitter`** — `dispatchChanges()` moved here from callers; single exhaustive loop replaces four separate loops
- **`NoteProvider`** — interface for ISO-date-keyed note persistence
- **`DailyNoteEditor`** — single-day editor with read-only date header and auto-save
- **`DailyNoteScrollView`** — infinite-scroll journal over a single `contenteditable`; cross-day boundary protection, rolling window via `IntersectionObserver`
- **`DailyNoteHistory`** — snapshot-based cross-day undo/redo; `updateOrAdd()` coalesces rapid character typing; `undo()`/`redo()` call `provider.save()` automatically and return `{ noteId, blocks, selection }` so the caller re-renders the correct section
- **`BlockEditor`** — adds `focusStart()`/`focusEnd()` and `onTopBoundaryEscape`/`onBottomBoundaryEscape` callbacks for cursor handoff across sections

## Testing

- [ ] Unit tests added/updated: `pnpm vitest run` → **643 tests, all passing**
- [ ] Type-checked: `pnpm check` → **0 errors, 0 warnings**
- [ ] `DailyNoteHistory.test.ts` — 25 tests: single-day, cross-day, redo-stack, coalescing, MAX_DEPTH
- [ ] `DailyNoteEditor.test.ts` — 10 tests: mount, load, save, focus, lifecycle
- [ ] `DailyNoteScrollView.test.ts` — 18 tests: rendering, boundary protection, rolling window, cross-day selection

## Breaking Changes

- [ ] No

## Related Issues

Closes #65

## Reviewer Notes

Review order: `BlockEventEmitter.ts` → `BlockRenderer.ts` → `InputHandler.ts` → `BlockEditor.ts` → `DailyNoteHistory.ts` → `DailyNoteEditor.ts` → `DailyNoteScrollView.ts`

Key design decision in `DailyNoteScrollView`: a single `DailyNoteHistory` instance replaces per-day `BlockHistory` for keyboard undo/redo. Each mutation point (`#handleInput`, `#handleKeyDown`, `#applyBlocksChange`) captures a before-snapshot before calling `InputHandler` and records the delta into `DailyNoteHistory`. The per-day `BlockHistory` still exists but is only used by `InputHandler` internally for its own coalescing; undo/redo bypasses it entirely.